### PR TITLE
DPL-773 Filter entries with no user info

### DIFF
--- a/janitor/helpers/mlwh_helpers.py
+++ b/janitor/helpers/mlwh_helpers.py
@@ -77,6 +77,7 @@ def sort_results(
         if (
             result_dict["unordered_barcode"] is None
             and result_dict["ordered_barcode"] is None
+            or result_dict["stored_by"] is None
         ):
             invalid_entries.append(result_dict)
         else:

--- a/janitor/helpers/mlwh_helpers.py
+++ b/janitor/helpers/mlwh_helpers.py
@@ -64,7 +64,7 @@ def sort_results(
     """Sort results to add to table and filter out entries missing location.
 
     Arguments:
-        entries {List[Dict[str, Any]]}: entries to sort
+        entries {Sequence[Any]}: entries to sort
 
     Returns:
         mlwh_entries {List[LabwareMLWHEntry]}: entries to add to MLWH table


### PR DESCRIPTION
This will stop the error regarding "stored_by" being null when trying to write to the new table by filtering these entries out and logging them.