### PR TITLE
DPL-773 Add unit tests for syncing labware locations task

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -15,6 +15,13 @@ jobs:
       contents: write
       packages: write
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
     steps:
       - uses: actions/checkout@v2
 
@@ -25,6 +32,20 @@ jobs:
           docker build .
           --file Dockerfile
           --tag docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
+
+      - name: Set up MySQL databases
+        run: |
+          mysql -e 'CREATE DATABASE janitor_tests_lw_input;' -uroot -h '127.0.0.1'
+          mysql -e 'CREATE DATABASE janitor_tests_mlwh_output;' -uroot -h '127.0.0.1'
+
+      - name: Run tests against the image
+        run: >-
+          docker run
+          --network host
+          --entrypoint ''
+          --env SETTINGS_MODULE=janitor.config.test
+          docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
+          python -m pytest --no-cov -vx
 
       - name: Set release name
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
       - develop
       - master
 
+env:
+  SETTINGS_MODULE: janitor.config.test
+
 jobs:
   black:
     runs-on: ubuntu-latest
@@ -84,3 +87,39 @@ jobs:
       - name: Run mypy
         run: |
           python -m mypy .
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install pipenv
+        run: |
+          pip install pipenv
+      - name: Install dependencies
+        run: |
+          pipenv sync --dev --system
+      - name: Set up MySQL databases
+        run: |
+          mysql -e 'CREATE DATABASE janitor_tests_lw_input;' -uroot -h '127.0.0.1'
+          mysql -e 'CREATE DATABASE janitor_tests_mlwh_output;' -uroot -h '127.0.0.1'
+      - name: Test with pytest
+        run: |
+          python -m pytest -vx
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 apscheduler = "~=3.10"
 mysql-connector-python = "~=8.0"
 python-dotenv = "~=1.0"
+pytest = "*"
+pytest-cov = "*"
 
 [dev-packages]
 black = "*"
@@ -16,3 +18,6 @@ mypy = "*"
 
 [requires]
 python_version = "3.10"
+
+[scripts]
+test = 'python -m pytest -vx'

--- a/Pipfile
+++ b/Pipfile
@@ -7,8 +7,8 @@ name = "pypi"
 apscheduler = "~=3.10"
 mysql-connector-python = "~=8.0"
 python-dotenv = "~=1.0"
-pytest = "*"
-pytest-cov = "*"
+pytest = "~=7.3"
+pytest-cov = "~=4.1"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "31b2c64549777540d53d0b5931f8930ea8e4d0aeecceef3d52334d1c964ff155"
+            "sha256": "26294e84bb79c25b4dad8d1d6eeb82c5dc58bb58a9441ad98cfb920d165fba63"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -186,11 +186,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295",
-                "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"
+                "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
+                "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
             ],
             "index": "pypi",
-            "version": "==7.3.2"
+            "version": "==7.4.0"
         },
         "pytest-cov": {
             "hashes": [
@@ -322,35 +322,35 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0cf0ca95e4b8adeaf07815a78b4096b65adf64ea7871b39a2116c19497fcd0dd",
-                "sha256:0f98973e39e4a98709546a9afd82e1ffcc50c6ec9ce6f7870f33ebbf0bd4f26d",
-                "sha256:19d42b08c7532d736a7e0fb29525855e355fa51fd6aef4f9bbc80749ff64b1a2",
-                "sha256:210fe0f39ec5be45dd9d0de253cb79245f0a6f27631d62e0c9c7988be7152965",
-                "sha256:3b1b5c875fcf3e7217a3de7f708166f641ca154b589664c44a6fd6d9f17d9e7e",
-                "sha256:3f2b353eebef669529d9bd5ae3566905a685ae98b3af3aad7476d0d519714758",
-                "sha256:50f65f0e9985f1e50040e603baebab83efed9eb37e15a22a4246fa7cd660f981",
-                "sha256:53c2a1fed81e05ded10a4557fe12bae05b9ecf9153f162c662a71d924d504135",
-                "sha256:5a0ee54c2cb0f957f8a6f41794d68f1a7e32b9968675ade5846f538504856d42",
-                "sha256:62bf18d97c6b089f77f0067b4e321db089d8520cdeefc6ae3ec0f873621c22e5",
-                "sha256:653863c75f0dbb687d92eb0d4bd9fe7047d096987ecac93bb7b1bc336de48ebd",
-                "sha256:67242d5b28ed0fa88edd8f880aed24da481929467fdbca6487167cb5e3fd31ff",
-                "sha256:6ba9a69172abaa73910643744d3848877d6aac4a20c41742027dcfd8d78f05d9",
-                "sha256:6c34d43e3d54ad05024576aef28081d9d0580f6fa7f131255f54020eb12f5352",
-                "sha256:7461469e163f87a087a5e7aa224102a30f037c11a096a0ceeb721cb0dce274c8",
-                "sha256:94a81b9354545123feb1a99b960faeff9e1fa204fce47e0042335b473d71530d",
-                "sha256:a0b2e0da7ff9dd8d2066d093d35a169305fc4e38db378281fce096768a3dbdbf",
-                "sha256:a34eed094c16cad0f6b0d889811592c7a9b7acf10d10a7356349e325d8704b4f",
-                "sha256:a3af348e0925a59213244f28c7c0c3a2c2088b4ba2fe9d6c8d4fbb0aba0b7d05",
-                "sha256:b4c734d947e761c7ceb1f09a98359dd5666460acbc39f7d0a6b6beec373c5840",
-                "sha256:bba57b4d2328740749f676807fcf3036e9de723530781405cc5a5e41fc6e20de",
-                "sha256:ca33ab70a4aaa75bb01086a0b04f0ba8441e51e06fc57e28585176b08cad533b",
-                "sha256:de1e7e68148a213036276d1f5303b3836ad9a774188961eb2684eddff593b042",
-                "sha256:f051ca656be0c179c735a4c3193f307d34c92fdc4908d44fd4516fbe8b10567d",
-                "sha256:f5984a8d13d35624e3b235a793c814433d810acba9eeefe665cdfed3d08bc3af",
-                "sha256:f7a5971490fd4a5a436e143105a1f78fa8b3fe95b30fff2a77542b4f3227a01f"
+                "sha256:01fd2e9f85622d981fd9063bfaef1aed6e336eaacca00892cd2d82801ab7c042",
+                "sha256:0dde1d180cd84f0624c5dcaaa89c89775550a675aff96b5848de78fb11adabcd",
+                "sha256:141dedfdbfe8a04142881ff30ce6e6653c9685b354876b12e4fe6c78598b45e2",
+                "sha256:16f0db5b641ba159eff72cff08edc3875f2b62b2fa2bc24f68c1e7a4e8232d01",
+                "sha256:190b6bab0302cec4e9e6767d3eb66085aef2a1cc98fe04936d8a42ed2ba77bb7",
+                "sha256:2460a58faeea905aeb1b9b36f5065f2dc9a9c6e4c992a6499a2360c6c74ceca3",
+                "sha256:34a9239d5b3502c17f07fd7c0b2ae6b7dd7d7f6af35fbb5072c6208e76295816",
+                "sha256:43b592511672017f5b1a483527fd2684347fdffc041c9ef53428c8dc530f79a3",
+                "sha256:43d24f6437925ce50139a310a64b2ab048cb2d3694c84c71c3f2a1626d8101dc",
+                "sha256:45d32cec14e7b97af848bddd97d85ea4f0db4d5a149ed9676caa4eb2f7402bb4",
+                "sha256:470c969bb3f9a9efcedbadcd19a74ffb34a25f8e6b0e02dae7c0e71f8372f97b",
+                "sha256:566e72b0cd6598503e48ea610e0052d1b8168e60a46e0bfd34b3acf2d57f96a8",
+                "sha256:5703097c4936bbb9e9bce41478c8d08edd2865e177dc4c52be759f81ee4dd26c",
+                "sha256:7549fbf655e5825d787bbc9ecf6028731973f78088fbca3a1f4145c39ef09462",
+                "sha256:8207b7105829eca6f3d774f64a904190bb2231de91b8b186d21ffd98005f14a7",
+                "sha256:8c4d8e89aa7de683e2056a581ce63c46a0c41e31bd2b6d34144e2c80f5ea53dc",
+                "sha256:98324ec3ecf12296e6422939e54763faedbfcc502ea4a4c38502082711867258",
+                "sha256:9bbcd9ab8ea1f2e1c8031c21445b511442cc45c89951e49bbf852cbb70755b1b",
+                "sha256:9d40652cc4fe33871ad3338581dca3297ff5f2213d0df345bcfbde5162abf0c9",
+                "sha256:a2746d69a8196698146a3dbe29104f9eb6a2a4d8a27878d92169a6c0b74435b6",
+                "sha256:ae704dcfaa180ff7c4cfbad23e74321a2b774f92ca77fd94ce1049175a21c97f",
+                "sha256:bfdca17c36ae01a21274a3c387a63aa1aafe72bff976522886869ef131b937f1",
+                "sha256:c482e1246726616088532b5e964e39765b6d1520791348e6c9dc3af25b233828",
+                "sha256:ca637024ca67ab24a7fd6f65d280572c3794665eaf5edcc7e90a866544076878",
+                "sha256:e02d700ec8d9b1859790c0475df4e4092c7bf3272a4fd2c9f33d87fac4427b8f",
+                "sha256:e5952d2d18b79f7dc25e62e014fe5a23eb1a3d2bc66318df8988a01b1a037c5b"
             ],
             "index": "pypi",
-            "version": "==1.4.0"
+            "version": "==1.4.1"
         },
         "mypy-extensions": {
             "hashes": [
@@ -378,11 +378,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:87fbf6473e87c078d536980ba970a472422e94f17b752cfad17024c18876d481",
-                "sha256:cfd065ba43133ff103ab3bd10aecb095c2a0035fcd1f07217c9376900d94ba07"
+                "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc",
+                "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.7.0"
+            "version": "==3.8.0"
         },
         "pycodestyle": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3749f2e9271068e82b9008c90e2bc3fbc17057a332c32713f311a314ebe90561"
+            "sha256": "31b2c64549777540d53d0b5931f8930ea8e4d0aeecceef3d52334d1c964ff155"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,91 @@
             ],
             "index": "pypi",
             "version": "==3.10.1"
+        },
+        "coverage": {
+            "extras": [
+                "toml"
+            ],
+            "hashes": [
+                "sha256:06a9a2be0b5b576c3f18f1a241f0473575c4a26021b52b2a85263a00f034d51f",
+                "sha256:06fb182e69f33f6cd1d39a6c597294cff3143554b64b9825d1dc69d18cc2fff2",
+                "sha256:0a5f9e1dbd7fbe30196578ca36f3fba75376fb99888c395c5880b355e2875f8a",
+                "sha256:0e1f928eaf5469c11e886fe0885ad2bf1ec606434e79842a879277895a50942a",
+                "sha256:171717c7cb6b453aebac9a2ef603699da237f341b38eebfee9be75d27dc38e01",
+                "sha256:1e9d683426464e4a252bf70c3498756055016f99ddaec3774bf368e76bbe02b6",
+                "sha256:201e7389591af40950a6480bd9edfa8ed04346ff80002cec1a66cac4549c1ad7",
+                "sha256:245167dd26180ab4c91d5e1496a30be4cd721a5cf2abf52974f965f10f11419f",
+                "sha256:2aee274c46590717f38ae5e4650988d1af340fe06167546cc32fe2f58ed05b02",
+                "sha256:2e07b54284e381531c87f785f613b833569c14ecacdcb85d56b25c4622c16c3c",
+                "sha256:31563e97dae5598556600466ad9beea39fb04e0229e61c12eaa206e0aa202063",
+                "sha256:33d6d3ea29d5b3a1a632b3c4e4f4ecae24ef170b0b9ee493883f2df10039959a",
+                "sha256:3d376df58cc111dc8e21e3b6e24606b5bb5dee6024f46a5abca99124b2229ef5",
+                "sha256:419bfd2caae268623dd469eff96d510a920c90928b60f2073d79f8fe2bbc5959",
+                "sha256:48c19d2159d433ccc99e729ceae7d5293fbffa0bdb94952d3579983d1c8c9d97",
+                "sha256:49969a9f7ffa086d973d91cec8d2e31080436ef0fb4a359cae927e742abfaaa6",
+                "sha256:52edc1a60c0d34afa421c9c37078817b2e67a392cab17d97283b64c5833f427f",
+                "sha256:537891ae8ce59ef63d0123f7ac9e2ae0fc8b72c7ccbe5296fec45fd68967b6c9",
+                "sha256:54b896376ab563bd38453cecb813c295cf347cf5906e8b41d340b0321a5433e5",
+                "sha256:58c2ccc2f00ecb51253cbe5d8d7122a34590fac9646a960d1430d5b15321d95f",
+                "sha256:5b7540161790b2f28143191f5f8ec02fb132660ff175b7747b95dcb77ac26562",
+                "sha256:5baa06420f837184130752b7c5ea0808762083bf3487b5038d68b012e5937dbe",
+                "sha256:5e330fc79bd7207e46c7d7fd2bb4af2963f5f635703925543a70b99574b0fea9",
+                "sha256:61b9a528fb348373c433e8966535074b802c7a5d7f23c4f421e6c6e2f1697a6f",
+                "sha256:63426706118b7f5cf6bb6c895dc215d8a418d5952544042c8a2d9fe87fcf09cb",
+                "sha256:6d040ef7c9859bb11dfeb056ff5b3872436e3b5e401817d87a31e1750b9ae2fb",
+                "sha256:6f48351d66575f535669306aa7d6d6f71bc43372473b54a832222803eb956fd1",
+                "sha256:7ee7d9d4822c8acc74a5e26c50604dff824710bc8de424904c0982e25c39c6cb",
+                "sha256:81c13a1fc7468c40f13420732805a4c38a105d89848b7c10af65a90beff25250",
+                "sha256:8d13c64ee2d33eccf7437961b6ea7ad8673e2be040b4f7fd4fd4d4d28d9ccb1e",
+                "sha256:8de8bb0e5ad103888d65abef8bca41ab93721647590a3f740100cd65c3b00511",
+                "sha256:8fa03bce9bfbeeef9f3b160a8bed39a221d82308b4152b27d82d8daa7041fee5",
+                "sha256:924d94291ca674905fe9481f12294eb11f2d3d3fd1adb20314ba89e94f44ed59",
+                "sha256:975d70ab7e3c80a3fe86001d8751f6778905ec723f5b110aed1e450da9d4b7f2",
+                "sha256:976b9c42fb2a43ebf304fa7d4a310e5f16cc99992f33eced91ef6f908bd8f33d",
+                "sha256:9e31cb64d7de6b6f09702bb27c02d1904b3aebfca610c12772452c4e6c21a0d3",
+                "sha256:a342242fe22407f3c17f4b499276a02b01e80f861f1682ad1d95b04018e0c0d4",
+                "sha256:a3d33a6b3eae87ceaefa91ffdc130b5e8536182cd6dfdbfc1aa56b46ff8c86de",
+                "sha256:a895fcc7b15c3fc72beb43cdcbdf0ddb7d2ebc959edac9cef390b0d14f39f8a9",
+                "sha256:afb17f84d56068a7c29f5fa37bfd38d5aba69e3304af08ee94da8ed5b0865833",
+                "sha256:b1c546aca0ca4d028901d825015dc8e4d56aac4b541877690eb76490f1dc8ed0",
+                "sha256:b29019c76039dc3c0fd815c41392a044ce555d9bcdd38b0fb60fb4cd8e475ba9",
+                "sha256:b46517c02ccd08092f4fa99f24c3b83d8f92f739b4657b0f146246a0ca6a831d",
+                "sha256:b7aa5f8a41217360e600da646004f878250a0d6738bcdc11a0a39928d7dc2050",
+                "sha256:b7b4c971f05e6ae490fef852c218b0e79d4e52f79ef0c8475566584a8fb3e01d",
+                "sha256:ba90a9563ba44a72fda2e85302c3abc71c5589cea608ca16c22b9804262aaeb6",
+                "sha256:cb017fd1b2603ef59e374ba2063f593abe0fc45f2ad9abdde5b4d83bd922a353",
+                "sha256:d22656368f0e6189e24722214ed8d66b8022db19d182927b9a248a2a8a2f67eb",
+                "sha256:d2c2db7fd82e9b72937969bceac4d6ca89660db0a0967614ce2481e81a0b771e",
+                "sha256:d39b5b4f2a66ccae8b7263ac3c8170994b65266797fb96cbbfd3fb5b23921db8",
+                "sha256:d62a5c7dad11015c66fbb9d881bc4caa5b12f16292f857842d9d1871595f4495",
+                "sha256:e7d9405291c6928619403db1d10bd07888888ec1abcbd9748fdaa971d7d661b2",
+                "sha256:e84606b74eb7de6ff581a7915e2dab7a28a0517fbe1c9239eb227e1354064dcd",
+                "sha256:eb393e5ebc85245347950143969b241d08b52b88a3dc39479822e073a1a8eb27",
+                "sha256:ebba1cd308ef115925421d3e6a586e655ca5a77b5bf41e02eb0e4562a111f2d1",
+                "sha256:ee57190f24fba796e36bb6d3aa8a8783c643d8fa9760c89f7a98ab5455fbf818",
+                "sha256:f2f67fe12b22cd130d34d0ef79206061bfb5eda52feb6ce0dba0644e20a03cf4",
+                "sha256:f6951407391b639504e3b3be51b7ba5f3528adbf1a8ac3302b687ecababf929e",
+                "sha256:f75f7168ab25dd93110c8a8117a22450c19976afbc44234cbf71481094c1b850",
+                "sha256:fdec9e8cbf13a5bf63290fc6013d216a4c7232efb51548594ca3631a7f13c3a3"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==7.2.7"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
+                "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.1"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "mysql-connector-python": {
             "hashes": [
@@ -55,6 +140,22 @@
             "index": "pypi",
             "version": "==8.0.33"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
+                "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.0"
+        },
         "protobuf": {
             "hashes": [
                 "sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7",
@@ -82,6 +183,22 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.20.3"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295",
+                "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"
+            ],
+            "index": "pypi",
+            "version": "==7.3.2"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6",
+                "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"
+            ],
+            "index": "pypi",
+            "version": "==4.1.0"
         },
         "python-dotenv": {
             "hashes": [
@@ -113,6 +230,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "tzlocal": {
             "hashes": [

--- a/janitor/config/test.py
+++ b/janitor/config/test.py
@@ -1,0 +1,27 @@
+# flake8: noqa
+from .defaults import *
+
+# setting here will overwrite those in 'defaults.py'
+SYNC_JOB_INTERVAL_SEC = 120
+SYNC_JOB_OVERLAP_SEC = 10
+
+LABWHERE_DB: DbConnectionDetails = {
+    "db_name": "janitor_tests_lw_input",
+    "host": "127.0.0.1",
+    "port": 3306,
+    "username": "root",
+    "password": "",
+}
+
+MLWH_DB: DbConnectionDetails = {
+    "db_name": "janitor_tests_mlwh_output",
+    "host": "127.0.0.1",
+    "port": 3306,
+    "username": "root",
+    "password": "",
+}
+
+# logging config
+LOGGING["loggers"]["janitor"]["level"] = "DEBUG"
+LOGGING["loggers"]["apscheduler"]["level"] = "DEBUG"
+LOGGING["handlers"]["console"]["level"] = "DEBUG"

--- a/janitor/config/test.py
+++ b/janitor/config/test.py
@@ -5,7 +5,7 @@ from .defaults import *
 SYNC_JOB_INTERVAL_SEC = 300
 SYNC_JOB_OVERLAP_SEC = 10
 
-LABWHERE_DB: DbConnectionDetails = {
+LABWHERE_DB: DbConnectionDetails = {  # type: ignore
     "db_name": "janitor_tests_lw_input",
     "host": "127.0.0.1",
     "port": 3306,
@@ -13,7 +13,7 @@ LABWHERE_DB: DbConnectionDetails = {
     "password": "",
 }
 
-MLWH_DB: DbConnectionDetails = {
+MLWH_DB: DbConnectionDetails = {  # type: ignore
     "db_name": "janitor_tests_mlwh_output",
     "host": "127.0.0.1",
     "port": 3306,

--- a/janitor/config/test.py
+++ b/janitor/config/test.py
@@ -2,7 +2,7 @@
 from .defaults import *
 
 # setting here will overwrite those in 'defaults.py'
-SYNC_JOB_INTERVAL_SEC = 120
+SYNC_JOB_INTERVAL_SEC = 300
 SYNC_JOB_OVERLAP_SEC = 10
 
 LABWHERE_DB: DbConnectionDetails = {

--- a/janitor/db/database.py
+++ b/janitor/db/database.py
@@ -5,7 +5,6 @@ from typing import List, Dict, Any, Sequence, cast
 from janitor.helpers.mysql_helpers import list_of_entries_values
 from janitor.types import DbConnectionDetails
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +22,7 @@ class Database:
             username=creds["username"],
             password=creds["password"],
         )
+
         self.connection = cast(MySQLConnectionAbstract, connection)
 
         self.cursor = self.connection.cursor()
@@ -68,9 +68,7 @@ class Database:
         while entries_index < num_entries:
             self.cursor.executemany(
                 query,
-                list_of_entries_values(
-                    entries[entries_index : entries_index + rows_per_query]  # noqa
-                ),
+                list_of_entries_values(entries[entries_index : entries_index + rows_per_query]),  # noqa
             )
             entries_index += rows_per_query
 

--- a/janitor/helpers/mlwh_helpers.py
+++ b/janitor/helpers/mlwh_helpers.py
@@ -75,17 +75,12 @@ def sort_results(
     for index in range(len(entries)):
         result_dict = parse_entry(entries[index], labware_labwhere_columns)
 
-        entry_has_no_barcode = (
-            result_dict["unordered_barcode"] is None
-            and result_dict["ordered_barcode"] is None
-        )
+        entry_has_no_barcode = result_dict["unordered_barcode"] is None and result_dict["ordered_barcode"] is None
         entry_has_no_valid_user = result_dict["stored_by"] is None
 
         if entry_has_no_barcode or entry_has_no_valid_user:
             invalid_entries.append(result_dict)
         else:
-            mlwh_entries.append(
-                make_mlwh_entry(cast(LabwareLabwhereEntry, result_dict))
-            )
+            mlwh_entries.append(make_mlwh_entry(cast(LabwareLabwhereEntry, result_dict)))
 
     return mlwh_entries, invalid_entries

--- a/janitor/helpers/mysql_helpers.py
+++ b/janitor/helpers/mysql_helpers.py
@@ -14,7 +14,7 @@ def load_query(filepath: str) -> str:
         return query.read()
 
 
-def parse_entry(entry: Dict[str, Any], column_names: List[str]) -> Dict[str, Any]:
+def parse_entry(entry: List[Any], column_names: List[str]) -> Dict[str, Any]:
     """Parse entry into dictionary form for easier indexing.
 
     Arguments:

--- a/janitor/tasks/labware_location/main.py
+++ b/janitor/tasks/labware_location/main.py
@@ -31,6 +31,8 @@ def sync_changes_from_labwhere(config):
         5000,
     )
 
+    logger.info("Closing connections to databases...")
     db_labwhere.close()
     db_mlwh.close()
+    logger.info("Task successful!")
     logger.info(f"Task complete in {round(time.time() - start, 2)}s")

--- a/janitor/tasks/labware_location/main.py
+++ b/janitor/tasks/labware_location/main.py
@@ -1,28 +1,20 @@
 import logging
 import time
-from os import path
+from janitor.tasks.labware_location.sql_queries.sql_queries import GET_LOCATIONS_QUERY, WRITE_TO_LABWARE_LOCATION_QUERY
 from janitor.db.database import Database
-from janitor.helpers.mysql_helpers import load_query
 from janitor.helpers.mlwh_helpers import sort_results
-from janitor.helpers.config_helpers import get_config
 
-config = get_config()
-
-wd = path.realpath(path.dirname(__file__))
 logger = logging.getLogger(__name__)
 
-GET_LOCATIONS_FILE = "get_labware_locations.sql"
-WRITE_TO_LABWARE_LOCATIONS_FILE = "write_to_labware_locations.sql"
 
-
-def sync_changes_from_labwhere():
+def sync_changes_from_labwhere(config):
     start = time.time()
     logger.info("Starting sync labware locations task...")
     db_labwhere = Database(config.LABWHERE_DB)
     db_mlwh = Database(config.MLWH_DB)
 
     results = db_labwhere.execute_query(
-        load_query(path.join(wd, "sql_queries", GET_LOCATIONS_FILE)),
+        GET_LOCATIONS_QUERY,
         {"interval": str(config.SYNC_JOB_INTERVAL_SEC + config.SYNC_JOB_OVERLAP_SEC)},
     )
 
@@ -34,7 +26,7 @@ def sync_changes_from_labwhere():
 
     logger.info(f"Updating {len(mlwh_entries)} rows...")
     db_mlwh.write_entries_to_table(
-        load_query(path.join(wd, "sql_queries", WRITE_TO_LABWARE_LOCATIONS_FILE)),
+        WRITE_TO_LABWARE_LOCATION_QUERY,
         mlwh_entries,
         5000,
     )

--- a/janitor/tasks/labware_location/sql_queries/sql_queries.py
+++ b/janitor/tasks/labware_location/sql_queries/sql_queries.py
@@ -1,0 +1,11 @@
+from os import path
+from janitor.helpers.mysql_helpers import load_query
+
+wd = path.realpath(path.dirname(__file__))
+
+
+GET_LOCATIONS_FILE = "get_labware_locations.sql"
+GET_LOCATIONS_QUERY = load_query(path.join(wd, GET_LOCATIONS_FILE))
+
+WRITE_TO_LABWARE_LOCATION_FILE = "write_to_labware_locations.sql"
+WRITE_TO_LABWARE_LOCATION_QUERY = load_query(path.join(wd, WRITE_TO_LABWARE_LOCATION_FILE))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 120
+
+[tool.coverage.run]
+branch = true
+source = ['janitor']

--- a/run.py
+++ b/run.py
@@ -12,9 +12,7 @@ logging.config.dictConfig(config.LOGGING)
 
 if __name__ == "__main__":
     sched = BackgroundScheduler(daemon=False)
-    sched.add_job(
-        sync_changes_from_labwhere, "interval", seconds=config.SYNC_JOB_INTERVAL_SEC
-    )
+    sched.add_job(sync_changes_from_labwhere, "interval", [config], seconds=config.SYNC_JOB_INTERVAL_SEC)
     sched.start()
     while True:
         sleep(300)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ show-source = True
 
 [tool:pytest]
 testpaths = tests
-addopts = --cov=janitor --cov=migrations --cov-report html --cov-report xml
+addopts = --cov=janitor --cov-report html --cov-report xml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,12 +115,16 @@ def lw_audits_table(lw_database, request):
     drop_table_query = f"DROP TABLE IF EXISTS {table_name};"
     lw_database.execute_query(drop_table_query, {})
 
-    cols = "id int(11) primary key, auditable_id int(11), auditable_type varchar(255), user_id int(11), updated_at datetime(6)"
+    cols = """
+    id int(11) primary key, auditable_id int(11), auditable_type varchar(255), user_id int(11), updated_at datetime(6)
+    """
     create_table_query = f"CREATE TABLE {table_name} ({cols});"
     lw_database.execute_query(create_table_query, {})
 
     if request.param:
-        insert_into_table_query = f"INSERT INTO {table_name} (id, auditable_id, auditable_type, user_id, updated_at) VALUES (%s, %s, %s, %s, %s);"
+        insert_into_table_query = f"""
+        INSERT INTO {table_name} (id, auditable_id, auditable_type, user_id, updated_at) VALUES (%s, %s, %s, %s, %s);
+        """
         lw_database.write_entries_to_table(insert_into_table_query, request.param, len(request.param))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 import pytest
+import logging.config
 from copy import deepcopy
 from janitor.db.database import Database
 from janitor.helpers.config_helpers import get_config
 from janitor.types import DbConnectionDetails
 
 CONFIG = get_config("janitor.config.test")
+logging.config.dictConfig(CONFIG.LOGGING)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,24 @@ def mlwh_creds(config):
 
 
 @pytest.fixture
+def labware_location_columns():
+    return [
+        "id",
+        "labware_barcode",
+        "location_barcode",
+        "full_location_address",
+        "coordinate_position",
+        "coordinate_row",
+        "coordinate_column",
+        "lims_id",
+        "stored_by",
+        "stored_at",
+        "created_at",
+        "updated_at",
+    ]
+
+
+@pytest.fixture
 def lw_database(lw_creds):
     try:
         # Create the database if it doesn't exist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,194 @@
+import pytest
+from copy import deepcopy
+from janitor.db.database import Database
+from janitor.helpers.config_helpers import get_config
+from janitor.types import DbConnectionDetails
+
+CONFIG = get_config("janitor.config.test")
+
+
+@pytest.fixture
+def config():
+    return CONFIG
+
+
+@pytest.fixture
+def mlwh_database(mlwh_creds):
+    try:
+        # Create the database if it doesn't exist
+        creds_without_database = deepcopy(mlwh_creds)
+        creds_without_database["db_name"] = ""
+
+        new_sql_conn = Database(creds_without_database)
+        new_sql_conn.execute_query(f"CREATE DATABASE IF NOT EXISTS {mlwh_creds['db_name']}", {})
+    finally:
+        new_sql_conn.close()
+
+    try:
+        mysql_conn = Database(mlwh_creds)
+        yield mysql_conn
+    finally:
+        mysql_conn.close()
+
+
+@pytest.fixture
+def mlwh_creds(config):
+    return DbConnectionDetails(
+        host=config.MLWH_DB["host"],
+        db_name=config.MLWH_DB["db_name"],
+        username=config.MLWH_DB["username"],
+        password=config.MLWH_DB["password"],
+        port=config.MLWH_DB["port"],
+    )
+
+
+@pytest.fixture
+def lw_database(lw_creds):
+    try:
+        # Create the database if it doesn't exist
+        creds_without_database = deepcopy(lw_creds)
+        creds_without_database["db_name"] = ""
+
+        new_sql_conn = Database(creds_without_database)
+        new_sql_conn.execute_query(f"CREATE DATABASE IF NOT EXISTS {lw_creds['db_name']}", {})
+    finally:
+        new_sql_conn.close()
+
+    try:
+        mysql_conn = Database(lw_creds)
+        yield mysql_conn
+    finally:
+        mysql_conn.close()
+
+
+@pytest.fixture
+def lw_creds(config):
+    return DbConnectionDetails(
+        host=config.LABWHERE_DB["host"],
+        db_name=config.LABWHERE_DB["db_name"],
+        username=config.LABWHERE_DB["username"],
+        password=config.LABWHERE_DB["password"],
+        port=config.LABWHERE_DB["port"],
+    )
+
+
+@pytest.fixture(params=[[]])
+def lw_labwares_table(lw_database, request):
+    table_name = "labwares"
+    drop_table_query = f"DROP TABLE IF EXISTS {table_name};"
+    lw_database.execute_query(drop_table_query, {})
+
+    cols = "id int(11) primary key, barcode varchar(255), location_id int(11), coordinate_id int(11)"
+    create_table_query = f"CREATE TABLE {table_name} ({cols});"
+    lw_database.execute_query(create_table_query, {})
+
+    if request.param:
+        insert_into_table_query = (
+            f"INSERT INTO {table_name} (id, barcode, location_id, coordinate_id) VALUES (%s, %s, %s, %s);"
+        )
+        lw_database.write_entries_to_table(insert_into_table_query, request.param, len(request.param))
+
+
+@pytest.fixture(params=[[]])
+def lw_audits_table(lw_database, request):
+    table_name = "audits"
+    drop_table_query = f"DROP TABLE IF EXISTS {table_name};"
+    lw_database.execute_query(drop_table_query, {})
+
+    cols = "id int(11) primary key, auditable_id int(11), auditable_type varchar(255), user_id int(11), updated_at datetime(6)"
+    create_table_query = f"CREATE TABLE {table_name} ({cols});"
+    lw_database.execute_query(create_table_query, {})
+
+    if request.param:
+        insert_into_table_query = f"INSERT INTO {table_name} (id, auditable_id, auditable_type, user_id, updated_at) VALUES (%s, %s, %s, %s, %s);"
+        lw_database.write_entries_to_table(insert_into_table_query, request.param, len(request.param))
+
+
+@pytest.fixture(params=[[]])
+def lw_users_table(lw_database, request):
+    table_name = "users"
+    drop_table_query = f"DROP TABLE IF EXISTS {table_name};"
+    lw_database.execute_query(drop_table_query, {})
+
+    cols = "id int(11) primary key, login varchar(255)"
+    create_table_query = f"CREATE TABLE {table_name} ({cols});"
+    lw_database.execute_query(create_table_query, {})
+
+    if request.param:
+        insert_into_table_query = f"INSERT INTO {table_name} (id, login) VALUES (%s, %s);"
+        lw_database.write_entries_to_table(insert_into_table_query, request.param, len(request.param))
+
+
+@pytest.fixture(params=[[]])
+def lw_locations_table(lw_database, request):
+    table_name = "locations"
+    drop_table_query = f"DROP TABLE IF EXISTS {table_name};"
+    lw_database.execute_query(drop_table_query, {})
+
+    cols = "id int(11) primary key, barcode varchar(255), parentage varchar(255)"
+    create_table_query = f"CREATE TABLE {table_name} ({cols});"
+    lw_database.execute_query(create_table_query, {})
+
+    if request.param:
+        insert_into_table_query = f"INSERT INTO {table_name} (id, barcode, parentage) VALUES (%s, %s, %s);"
+        lw_database.write_entries_to_table(insert_into_table_query, request.param, len(request.param))
+
+
+@pytest.fixture(params=[[]])
+def lw_coordinates_table(lw_database, request):
+    table_name = "coordinates"
+    drop_table_query = f"DROP TABLE IF EXISTS {table_name};"
+    lw_database.execute_query(drop_table_query, {})
+
+    cols = "id int(11) primary key, `position` int(11), `row` int(11), `column` int(11), location_id int(11)"
+    create_table_query = f"CREATE TABLE {table_name} ({cols});"
+    lw_database.execute_query(create_table_query, {})
+
+    if request.param:
+        insert_into_table_query = (
+            f"INSERT INTO {table_name} (id, `position`, `row`, `column`, location_id) VALUES (%s, %s, %s, %s, %s);"
+        )
+        lw_database.write_entries_to_table(insert_into_table_query, request.param, len(request.param))
+
+
+@pytest.fixture(params=[[]])
+def mlwh_labware_locations_table(mlwh_database, request):
+    table_name = "labware_location"
+    drop_table_query = f"DROP TABLE IF EXISTS {table_name};"
+    mlwh_database.execute_query(drop_table_query, {})
+
+    cols = """
+        id int(11) primary key NOT NULL AUTO_INCREMENT,
+        labware_barcode varchar(255) NOT NULL UNIQUE,
+        location_barcode varchar(255) NOT NULL,
+        full_location_address varchar(255) NOT NULL,
+        coordinate_position int(11),
+        coordinate_row int(11),
+        coordinate_column int(11),
+        lims_id varchar(255) NOT NULL,
+        stored_by varchar(255) NOT NULL,
+        stored_at datetime(6) NOT NULL,
+        created_at datetime(6) NOT NULL,
+        updated_at datetime(6) NOT NULL
+    """
+    create_table_query = f"CREATE TABLE {table_name} ({cols});"
+    mlwh_database.execute_query(create_table_query, {})
+
+    if request.param:
+        insert_into_table_query = f"""
+                INSERT INTO {table_name}
+                (
+                    id,
+                    labware_barcode,
+                    location_barcode,
+                    full_location_address,
+                    coordinate_position,
+                    coordinate_row,
+                    coordinate_column,
+                    lims_id,
+                    stored_by,
+                    stored_at,
+                    created_at,
+                    updated_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);"""
+        mlwh_database.write_entries_to_table(insert_into_table_query, request.param, len(request.param))

--- a/tests/data/test_entries.py
+++ b/tests/data/test_entries.py
@@ -9,7 +9,16 @@ from tests.types import (
 )
 
 
-def get_time(delta_mins: datetime):
+def get_time(delta_mins: int) -> datetime:
+    """
+    Get current time minus specified number of minutes.
+
+    Parameters:
+        delta_mins {int}: Number of minutes to subtract
+
+    Returns:
+        {datetime}: Current time minus minutes
+    """
     return (datetime.utcnow() - timedelta(minutes=delta_mins)).replace(microsecond=0, second=0)
 
 

--- a/tests/data/test_entries.py
+++ b/tests/data/test_entries.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+from tests.types import (
+    LabwaresTableEntry,
+    AuditsTableEntry,
+    UsersTableEntry,
+    LocationsTableEntry,
+    CoordinatesTableEntry,
+    LabwareLocationTableEntry,
+)
+
+
+TEST_ENTRIES = {
+    "good_input_entry_with_location": {
+        "labwares": [LabwaresTableEntry(id=1, barcode="labware1", location_id=1, coordinate_id=None)],
+        "audits": [
+            AuditsTableEntry(id=1, auditable_id=1, auditable_type="Labware", user_id=1, updated_at=datetime.utcnow())
+        ],
+        "users": [UsersTableEntry(id=1, login="user1")],
+        "locations": [
+            LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1")
+        ],
+    },
+    "good_input_entry_with_coordinates": {
+        "labwares": [LabwaresTableEntry(id=2, barcode="labware2", location_id=None, coordinate_id=2)],
+        "audits": [
+            AuditsTableEntry(id=2, auditable_id=2, auditable_type="Labware", user_id=2, updated_at=datetime.utcnow())
+        ],
+        "users": [UsersTableEntry(id=2, login="user2")],
+        "locations": [LocationsTableEntry(id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2")],
+        "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
+    },
+    "good_input_entry_with_two_audits": {
+        "labwares": [LabwaresTableEntry(id=3, barcode="labware3", location_id=3, coordinate_id=None)],
+        "audits": [
+            AuditsTableEntry(id=3, auditable_id=3, auditable_type="Labware", user_id=3, updated_at=datetime.utcnow()),
+            AuditsTableEntry(id=4, auditable_id=3, auditable_type="Labware", user_id=4, updated_at=datetime.utcnow()),
+        ],
+        "users": [UsersTableEntry(id=3, login="user3"), UsersTableEntry(id=4, login="user4")],
+        "locations": [
+            LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3")
+        ],
+    },
+    "bad_input_entry_without_location_info": {
+        "labwares": [LabwaresTableEntry(id=4, barcode="labware4", location_id=None, coordinate_id=None)],
+        "audits": [
+            AuditsTableEntry(id=5, auditable_id=4, auditable_type="Labware", user_id=5, updated_at=datetime.utcnow())
+        ],
+        "users": [UsersTableEntry(id=5, login="user5")],
+    },
+    "bad_input_entry_with_location_without_audits": {
+        "labwares": [LabwaresTableEntry(id=5, barcode="labware5", location_id=4, coordinate_id=None)],
+        "locations": [
+            LocationsTableEntry(id=4, barcode="unordered_location4", parentage="PARENT / unordered_location4")
+        ],
+    },
+    "bad_input_entry_with_coordinates_without_audits": {
+        "labwares": [LabwaresTableEntry(id=6, barcode="labware6", location_id=None, coordinate_id=5)],
+        "locations": [LocationsTableEntry(id=5, barcode="ordered_location5", parentage="PARENT / ordered_location5")],
+        "coordinates": [CoordinatesTableEntry(id=5, position=1, row=1, column=1, location_id=5)],
+    },
+    "bad_input_entry_without_location_without_audits": {
+        "labwares": [LabwaresTableEntry(id=7, barcode="labware7", location_id=None, coordinate_id=None)],
+    },
+    "good_updated_input_entry": {
+        "labwares": [LabwaresTableEntry(id=1, barcode="labware1", location_id=3, coordinate_id=None)],
+        "audits": [
+            AuditsTableEntry(id=1, auditable_id=1, auditable_type="Labware", user_id=1, updated_at=datetime.utcnow()),
+            AuditsTableEntry(id=2, auditable_id=1, auditable_type="Labware", user_id=3, updated_at=datetime.utcnow()),
+        ],
+        "users": [UsersTableEntry(id=1, login="user1"), UsersTableEntry(id=3, login="user3")],
+        "locations": [
+            LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1"),
+            LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3"),
+        ],
+        "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
+    },
+    "good_outdated_output_entry": {
+        "labware_location": [
+            LabwareLocationTableEntry(
+                id=1,
+                labware_barcode="labware1",
+                location_barcode="unordered_location1",
+                full_location_address="PARENT / unordered_location1",
+                coordinate_position=None,
+                coordinate_row=None,
+                coordinate_column=None,
+                lims_id="LabWhere",
+                stored_by="user1",
+                stored_at=datetime.utcnow(),
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+            )
+        ]
+    },
+}

--- a/tests/data/test_entries.py
+++ b/tests/data/test_entries.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from tests.types import (
     LabwaresTableEntry,
     AuditsTableEntry,
@@ -9,87 +9,341 @@ from tests.types import (
 )
 
 
+def get_time(delta_mins: datetime):
+    return (datetime.utcnow() - timedelta(minutes=delta_mins)).replace(microsecond=0, second=0)
+
+
 TEST_ENTRIES = {
     "good_input_entry_with_location": {
-        "labwares": [LabwaresTableEntry(id=1, barcode="labware1", location_id=1, coordinate_id=None)],
-        "audits": [
-            AuditsTableEntry(id=1, auditable_id=1, auditable_type="Labware", user_id=1, updated_at=datetime.utcnow())
-        ],
-        "users": [UsersTableEntry(id=1, login="user1")],
-        "locations": [
-            LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1")
-        ],
+        "input_lw": {
+            "labwares": [LabwaresTableEntry(id=1, barcode="labware1", location_id=1, coordinate_id=None)],
+            "audits": [
+                AuditsTableEntry(
+                    id=1,
+                    auditable_id=1,
+                    auditable_type="Labware",
+                    user_id=1,
+                    updated_at=get_time(delta_mins=3),
+                )
+            ],
+            "users": [UsersTableEntry(id=1, login="user1")],
+            "locations": [
+                LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1")
+            ],
+        },
+        "output_mlwh_expected": {
+            "labware_location": [
+                LabwareLocationTableEntry(
+                    id=1,
+                    labware_barcode="labware1",
+                    location_barcode="unordered_location1",
+                    full_location_address="PARENT / unordered_location1",
+                    coordinate_position=None,
+                    coordinate_row=None,
+                    coordinate_column=None,
+                    lims_id="LabWhere",
+                    stored_by="user1",
+                    stored_at=get_time(delta_mins=3),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                )
+            ]
+        },
     },
     "good_input_entry_with_coordinates": {
-        "labwares": [LabwaresTableEntry(id=2, barcode="labware2", location_id=None, coordinate_id=2)],
-        "audits": [
-            AuditsTableEntry(id=2, auditable_id=2, auditable_type="Labware", user_id=2, updated_at=datetime.utcnow())
-        ],
-        "users": [UsersTableEntry(id=2, login="user2")],
-        "locations": [LocationsTableEntry(id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2")],
-        "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
+        "input_lw": {
+            "labwares": [LabwaresTableEntry(id=2, barcode="labware2", location_id=None, coordinate_id=2)],
+            "audits": [
+                AuditsTableEntry(
+                    id=2,
+                    auditable_id=2,
+                    auditable_type="Labware",
+                    user_id=2,
+                    updated_at=get_time(delta_mins=3),
+                )
+            ],
+            "users": [UsersTableEntry(id=2, login="user2")],
+            "locations": [
+                LocationsTableEntry(id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2")
+            ],
+            "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
+        },
+        "output_mlwh_expected": {
+            "labware_location": [
+                LabwareLocationTableEntry(
+                    id=1,
+                    labware_barcode="labware2",
+                    location_barcode="ordered_location2",
+                    full_location_address="PARENT / ordered_location2",
+                    coordinate_position=1,
+                    coordinate_row=1,
+                    coordinate_column=1,
+                    lims_id="LabWhere",
+                    stored_by="user2",
+                    stored_at=get_time(delta_mins=3),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                )
+            ]
+        },
     },
     "good_input_entry_with_two_audits": {
-        "labwares": [LabwaresTableEntry(id=3, barcode="labware3", location_id=3, coordinate_id=None)],
-        "audits": [
-            AuditsTableEntry(id=3, auditable_id=3, auditable_type="Labware", user_id=3, updated_at=datetime.utcnow()),
-            AuditsTableEntry(id=4, auditable_id=3, auditable_type="Labware", user_id=4, updated_at=datetime.utcnow()),
-        ],
-        "users": [UsersTableEntry(id=3, login="user3"), UsersTableEntry(id=4, login="user4")],
-        "locations": [
-            LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3")
-        ],
+        "input_lw": {
+            "labwares": [LabwaresTableEntry(id=3, barcode="labware3", location_id=3, coordinate_id=None)],
+            "audits": [
+                AuditsTableEntry(
+                    id=3,
+                    auditable_id=3,
+                    auditable_type="Labware",
+                    user_id=3,
+                    updated_at=get_time(delta_mins=4),
+                ),
+                AuditsTableEntry(
+                    id=4,
+                    auditable_id=3,
+                    auditable_type="Labware",
+                    user_id=4,
+                    updated_at=get_time(delta_mins=2),
+                ),
+            ],
+            "users": [UsersTableEntry(id=3, login="user3"), UsersTableEntry(id=4, login="user4")],
+            "locations": [
+                LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3")
+            ],
+        },
+        "output_mlwh_expected": {
+            "labware_location": [
+                LabwareLocationTableEntry(
+                    id=1,
+                    labware_barcode="labware3",
+                    location_barcode="unordered_location3",
+                    full_location_address="PARENT / unordered_location3",
+                    coordinate_position=None,
+                    coordinate_row=None,
+                    coordinate_column=None,
+                    lims_id="LabWhere",
+                    stored_by="user4",
+                    stored_at=get_time(delta_mins=2),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                )
+            ]
+        },
     },
-    "bad_input_entry_without_location_info": {
-        "labwares": [LabwaresTableEntry(id=4, barcode="labware4", location_id=None, coordinate_id=None)],
-        "audits": [
-            AuditsTableEntry(id=5, auditable_id=4, auditable_type="Labware", user_id=5, updated_at=datetime.utcnow())
-        ],
-        "users": [UsersTableEntry(id=5, login="user5")],
+    "good_input_entry_outdated_record_in_mlwh": {
+        "input_lw": {
+            "labwares": [LabwaresTableEntry(id=4, barcode="labware4", location_id=4, coordinate_id=None)],
+            "audits": [
+                AuditsTableEntry(
+                    id=1,
+                    auditable_id=4,
+                    auditable_type="Labware",
+                    user_id=3,
+                    updated_at=get_time(delta_mins=4),
+                ),
+                AuditsTableEntry(
+                    id=2,
+                    auditable_id=4,
+                    auditable_type="Labware",
+                    user_id=4,
+                    updated_at=get_time(delta_mins=2),
+                ),
+            ],
+            "users": [UsersTableEntry(id=3, login="user3"), UsersTableEntry(id=4, login="user4")],
+            "locations": [
+                LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3"),
+                LocationsTableEntry(id=4, barcode="unordered_location4", parentage="PARENT / unordered_location4"),
+            ],
+        },
+        "input_mlwh": {
+            "labware_location": [
+                LabwareLocationTableEntry(
+                    id=1,
+                    labware_barcode="labware4",
+                    location_barcode="unordered_location3",
+                    full_location_address="PARENT / unordered_location3",
+                    coordinate_position=None,
+                    coordinate_row=None,
+                    coordinate_column=None,
+                    lims_id="LabWhere",
+                    stored_by="user3",
+                    stored_at=get_time(delta_mins=4),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                )
+            ]
+        },
+        "output_mlwh_expected": {
+            "labware_location": [
+                LabwareLocationTableEntry(
+                    id=1,
+                    labware_barcode="labware4",
+                    location_barcode="unordered_location4",
+                    full_location_address="PARENT / unordered_location4",
+                    coordinate_position=None,
+                    coordinate_row=None,
+                    coordinate_column=None,
+                    lims_id="LabWhere",
+                    stored_by="user4",
+                    stored_at=get_time(delta_mins=2),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                )
+            ]
+        },
     },
-    "bad_input_entry_with_location_without_audits": {
-        "labwares": [LabwaresTableEntry(id=5, barcode="labware5", location_id=4, coordinate_id=None)],
-        "locations": [
-            LocationsTableEntry(id=4, barcode="unordered_location4", parentage="PARENT / unordered_location4")
-        ],
+    "bad_input_entry_without_location": {
+        "input_lw": {
+            "labwares": [LabwaresTableEntry(id=5, barcode="labware5", location_id=None, coordinate_id=None)],
+            "audits": [
+                AuditsTableEntry(
+                    id=5,
+                    auditable_id=5,
+                    auditable_type="Labware",
+                    user_id=5,
+                    updated_at=get_time(delta_mins=0),
+                )
+            ],
+            "users": [UsersTableEntry(id=5, login="user5")],
+        },
     },
-    "bad_input_entry_with_coordinates_without_audits": {
-        "labwares": [LabwaresTableEntry(id=6, barcode="labware6", location_id=None, coordinate_id=5)],
-        "locations": [LocationsTableEntry(id=5, barcode="ordered_location5", parentage="PARENT / ordered_location5")],
-        "coordinates": [CoordinatesTableEntry(id=5, position=1, row=1, column=1, location_id=5)],
+    "bad_input_entry_without_audits": {
+        "input_lw": {
+            "labwares": [LabwaresTableEntry(id=6, barcode="labware6", location_id=6, coordinate_id=None)],
+            "locations": [
+                LocationsTableEntry(id=6, barcode="unordered_location6", parentage="PARENT / unordered_location6")
+            ],
+        },
     },
     "bad_input_entry_without_location_without_audits": {
-        "labwares": [LabwaresTableEntry(id=7, barcode="labware7", location_id=None, coordinate_id=None)],
+        "input_lw": {
+            "labwares": [LabwaresTableEntry(id=7, barcode="labware7", location_id=None, coordinate_id=None)],
+        },
     },
-    "good_updated_input_entry": {
-        "labwares": [LabwaresTableEntry(id=1, barcode="labware1", location_id=3, coordinate_id=None)],
-        "audits": [
-            AuditsTableEntry(id=1, auditable_id=1, auditable_type="Labware", user_id=1, updated_at=datetime.utcnow()),
-            AuditsTableEntry(id=2, auditable_id=1, auditable_type="Labware", user_id=3, updated_at=datetime.utcnow()),
-        ],
-        "users": [UsersTableEntry(id=1, login="user1"), UsersTableEntry(id=3, login="user3")],
-        "locations": [
-            LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1"),
-            LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3"),
-        ],
-        "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
-    },
-    "good_outdated_output_entry": {
-        "labware_location": [
-            LabwareLocationTableEntry(
-                id=1,
-                labware_barcode="labware1",
-                location_barcode="unordered_location1",
-                full_location_address="PARENT / unordered_location1",
-                coordinate_position=None,
-                coordinate_row=None,
-                coordinate_column=None,
-                lims_id="LabWhere",
-                stored_by="user1",
-                stored_at=datetime.utcnow(),
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
-            )
-        ]
+    "mixed_input_entries": {
+        "input_lw": {
+            "labwares": [
+                LabwaresTableEntry(id=1, barcode="labware1", location_id=1, coordinate_id=None),
+                LabwaresTableEntry(id=2, barcode="labware2", location_id=None, coordinate_id=None),
+                LabwaresTableEntry(id=3, barcode="labware3", location_id=None, coordinate_id=2),
+                LabwaresTableEntry(id=4, barcode="labware4", location_id=3, coordinate_id=None),
+                LabwaresTableEntry(id=5, barcode="labware5", location_id=3, coordinate_id=None),
+                LabwaresTableEntry(id=6, barcode="labware6", location_id=None, coordinate_id=None),
+                LabwaresTableEntry(id=7, barcode="labware7", location_id=4, coordinate_id=None),
+            ],
+            "audits": [
+                AuditsTableEntry(
+                    id=1,
+                    auditable_id=1,
+                    auditable_type="Labware",
+                    user_id=1,
+                    updated_at=get_time(delta_mins=4),
+                ),
+                AuditsTableEntry(
+                    id=2,
+                    auditable_id=2,
+                    auditable_type="Labware",
+                    user_id=2,
+                    updated_at=get_time(delta_mins=4),
+                ),
+                AuditsTableEntry(
+                    id=3,
+                    auditable_id=3,
+                    auditable_type="Labware",
+                    user_id=3,
+                    updated_at=get_time(delta_mins=3),
+                ),
+                AuditsTableEntry(
+                    id=4,
+                    auditable_id=5,
+                    auditable_type="Labware",
+                    user_id=5,
+                    updated_at=get_time(delta_mins=2),
+                ),
+                AuditsTableEntry(
+                    id=5,
+                    auditable_id=7,
+                    auditable_type="Labware",
+                    user_id=7,
+                    updated_at=get_time(delta_mins=1),
+                ),
+            ],
+            "users": [
+                UsersTableEntry(id=1, login="user1"),
+                UsersTableEntry(id=2, login="user2"),
+                UsersTableEntry(id=3, login="user3"),
+                UsersTableEntry(id=4, login="user4"),
+                UsersTableEntry(id=5, login="user5"),
+                UsersTableEntry(id=6, login="user6"),
+                UsersTableEntry(id=7, login="user7"),
+            ],
+            "locations": [
+                LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1"),
+                LocationsTableEntry(id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2"),
+                LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3"),
+                LocationsTableEntry(id=4, barcode="unordered_location4", parentage="PARENT / unordered_location4"),
+            ],
+            "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
+        },
+        "output_mlwh_expected": {
+            "labware_location": [
+                LabwareLocationTableEntry(
+                    id=1,
+                    labware_barcode="labware1",
+                    location_barcode="unordered_location1",
+                    full_location_address="PARENT / unordered_location1",
+                    coordinate_position=None,
+                    coordinate_row=None,
+                    coordinate_column=None,
+                    lims_id="LabWhere",
+                    stored_by="user1",
+                    stored_at=get_time(delta_mins=4),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                ),
+                LabwareLocationTableEntry(
+                    id=2,
+                    labware_barcode="labware3",
+                    location_barcode="ordered_location2",
+                    full_location_address="PARENT / ordered_location2",
+                    coordinate_position=1,
+                    coordinate_row=1,
+                    coordinate_column=1,
+                    lims_id="LabWhere",
+                    stored_by="user3",
+                    stored_at=get_time(delta_mins=3),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                ),
+                LabwareLocationTableEntry(
+                    id=3,
+                    labware_barcode="labware5",
+                    location_barcode="unordered_location3",
+                    full_location_address="PARENT / unordered_location3",
+                    coordinate_position=None,
+                    coordinate_row=None,
+                    coordinate_column=None,
+                    lims_id="LabWhere",
+                    stored_by="user5",
+                    stored_at=get_time(delta_mins=2),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                ),
+                LabwareLocationTableEntry(
+                    id=4,
+                    labware_barcode="labware7",
+                    location_barcode="unordered_location4",
+                    full_location_address="PARENT / unordered_location4",
+                    coordinate_position=None,
+                    coordinate_row=None,
+                    coordinate_column=None,
+                    lims_id="LabWhere",
+                    stored_by="user7",
+                    stored_at=get_time(delta_mins=1),
+                    created_at=get_time(delta_mins=0),
+                    updated_at=get_time(delta_mins=0),
+                ),
+            ]
+        },
     },
 }

--- a/tests/data/test_entries.py
+++ b/tests/data/test_entries.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Dict, Any
 from tests.types import (
     LabwaresTableEntry,
     AuditsTableEntry,
@@ -22,7 +23,7 @@ def get_time(delta_mins: int) -> datetime:
     return (datetime.utcnow() - timedelta(minutes=delta_mins)).replace(microsecond=0, second=0)
 
 
-TEST_ENTRIES = {
+TEST_ENTRIES: Dict[str, Any] = {
     "good_input_entry_with_location": {
         "input_lw": {
             "labwares": [LabwaresTableEntry(id=1, barcode="labware1", location_id=1, coordinate_id=None)],

--- a/tests/db/test_database.py
+++ b/tests/db/test_database.py
@@ -10,7 +10,7 @@ test_config = DbConnectionDetails(
 
 
 @patch("logging.error")
-def test_given_invalid_connection_when_connecting_to_db_then_check_error_messages_logged(mock_error, config):
+def test_given_invalid_connection_when_connecting_to_db_then_check_error_messages_logged(mock_error):
     with patch("mysql.connector.connect", side_effect=mysql.connector.Error()):
         Database(test_config)
         assert mock_error.has_calls(
@@ -20,7 +20,7 @@ def test_given_invalid_connection_when_connecting_to_db_then_check_error_message
 
 
 @patch("logging.error")
-def test_given_invalid_connection_when_closing_connection_then_check_error_message_logged(mock_error, config):
+def test_given_invalid_connection_when_closing_connection_then_check_error_message_logged(mock_error):
     with patch("mysql.connector.cursor") as mock_execute:
         mock_execute.return_value.execute.return_value = AttributeError("Database not connected")
         test_db = Database(test_config)
@@ -31,7 +31,7 @@ def test_given_invalid_connection_when_closing_connection_then_check_error_messa
 
 
 @patch("logging.error")
-def test_given_error_when_executing_sql_query_then_check_error_message_logged(mock_error, config):
+def test_given_error_when_executing_sql_query_then_check_error_message_logged(mock_error):
     with patch("mysql.connector.cursor") as mock_execute:
         mock_execute.return_value.execute.return_value = AttributeError("Database not connected")
         test_db = Database(test_config)
@@ -42,7 +42,7 @@ def test_given_error_when_executing_sql_query_then_check_error_message_logged(mo
 
 
 @patch("logging.error")
-def test_given_error_when_writing_to_table_then_check_error_message_logged(mock_error, config):
+def test_given_error_when_writing_to_table_then_check_error_message_logged(mock_error):
     with patch("mysql.connector.cursor") as mock_execute:
         mock_execute.return_value.executemany.return_value = AttributeError("Database not connected")
         test_db = Database(test_config)

--- a/tests/db/test_database.py
+++ b/tests/db/test_database.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch, call
+import mysql.connector
+from janitor.db.database import Database
+from janitor.types import DbConnectionDetails
+
+
+test_config = DbConnectionDetails(
+    host="test_host", port=1, db_name="test_dbname", username="test_username", password="test_password"
+)
+
+
+@patch("logging.error")
+def test_given_invalid_connection_when_connecting_to_db_then_check_error_messages_logged(mock_error, config):
+    with patch("mysql.connector.connect", side_effect=mysql.connector.Error()):
+        Database(test_config)
+        assert mock_error.has_calls(
+            call("MySQL connection failed!"),
+            call(f"Exception on connecting to MySQL database: {mysql.connector.Error()}"),
+        )
+
+
+@patch("logging.error")
+def test_given_invalid_connection_when_closing_connection_then_check_error_message_logged(mock_error, config):
+    with patch("mysql.connector.cursor") as mock_execute:
+        mock_execute.return_value.execute.return_value = AttributeError("Database not connected")
+        test_db = Database(test_config)
+        test_db.close()
+        assert mock_error.has_calls(
+            call(f"Exception on closing connection:  {AttributeError('Database not connected')}"),
+        )
+
+
+@patch("logging.error")
+def test_given_error_when_executing_sql_query_then_check_error_message_logged(mock_error, config):
+    with patch("mysql.connector.cursor") as mock_execute:
+        mock_execute.return_value.execute.return_value = AttributeError("Database not connected")
+        test_db = Database(test_config)
+        test_db.execute_query("query", {})
+        assert mock_error.has_calls(
+            call(f"Exception on executing query:  {AttributeError('Database not connected')}"),
+        )
+
+
+@patch("logging.error")
+def test_given_error_when_writing_to_table_then_check_error_message_logged(mock_error, config):
+    with patch("mysql.connector.cursor") as mock_execute:
+        mock_execute.return_value.executemany.return_value = AttributeError("Database not connected")
+        test_db = Database(test_config)
+        test_db.write_entries_to_table("query", [], 5000)
+        assert mock_error.has_calls(
+            call(f"Exception on writing entries:  {AttributeError('Database not connected')}"),
+        )

--- a/tests/db/test_database.py
+++ b/tests/db/test_database.py
@@ -21,19 +21,19 @@ def test_given_invalid_connection_when_connecting_to_db_then_check_error_message
 
 @patch("logging.error")
 def test_given_invalid_connection_when_closing_connection_then_check_error_message_logged(mock_error):
-    with patch("mysql.connector.cursor") as mock_execute:
-        mock_execute.return_value.execute.return_value = AttributeError("Database not connected")
+    with patch("mysql.connector.connect") as mock_connect:
+        mock_connect.return_value.close.return_value = mysql.connector.Error()
         test_db = Database(test_config)
         test_db.close()
         assert mock_error.has_calls(
-            call(f"Exception on closing connection:  {AttributeError('Database not connected')}"),
+            call(f"Exception on closing connection:  {mysql.connector.Error()}"),
         )
 
 
 @patch("logging.error")
 def test_given_error_when_executing_sql_query_then_check_error_message_logged(mock_error):
-    with patch("mysql.connector.cursor") as mock_execute:
-        mock_execute.return_value.execute.return_value = AttributeError("Database not connected")
+    with patch("mysql.connector.cursor") as mock_cursor:
+        mock_cursor.return_value.execute.return_value = AttributeError("Database not connected")
         test_db = Database(test_config)
         test_db.execute_query("query", {})
         assert mock_error.has_calls(
@@ -43,8 +43,8 @@ def test_given_error_when_executing_sql_query_then_check_error_message_logged(mo
 
 @patch("logging.error")
 def test_given_error_when_writing_to_table_then_check_error_message_logged(mock_error):
-    with patch("mysql.connector.cursor") as mock_execute:
-        mock_execute.return_value.executemany.return_value = AttributeError("Database not connected")
+    with patch("mysql.connector.cursor") as mock_cursor:
+        mock_cursor.return_value.executemany.return_value = AttributeError("Database not connected")
         test_db = Database(test_config)
         test_db.write_entries_to_table("query", [], 5000)
         assert mock_error.has_calls(

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -1,39 +1,8 @@
 import pytest
 from unittest.mock import patch, call
-import mysql.connector
 from janitor.tasks.labware_location.main import sync_changes_from_labwhere
 from janitor.helpers.mysql_helpers import parse_entry
 from tests.data.test_entries import TEST_ENTRIES
-
-
-@patch("logging.error")
-def test_given_invalid_connection_when_connecting_to_db_then_check_error_messages_logged(mock_error, config):
-    with patch("mysql.connector.connect", side_effect=mysql.connector.Error()):
-        sync_changes_from_labwhere(config)
-        assert mock_error.has_calls(
-            call("MySQL connection failed!"),
-            call(f"Exception on connecting to MySQL database: {mysql.connector.Error()}"),
-        )
-
-
-@patch("logging.error")
-def test_given_error_when_executing_sql_query_then_check_error_messages_logged(mock_error, config):
-    with patch("mysql.connector.cursor") as mock_execute:
-        mock_execute.return_value.execute.return_value = AttributeError("Database not connected")
-        sync_changes_from_labwhere(config)
-        assert mock_error.has_calls(
-            call(f"Exception on executing query:  {AttributeError('Database not connected')}"),
-        )
-
-
-@patch("logging.error")
-def test_given_error_when_writing_to_table_then_check_error_messages_logged(mock_error, config):
-    with patch("mysql.connector.cursor") as mock_execute:
-        mock_execute.return_value.executemany.return_value = AttributeError("Database not connected")
-        sync_changes_from_labwhere(config)
-        assert mock_error.has_calls(
-            call(f"Exception on writing entries:  {AttributeError('Database not connected')}"),
-        )
 
 
 @patch("logging.info")

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -243,7 +243,7 @@ def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_chec
     indirect=True,
 )
 @patch("janitor.tasks.labware_location.main.logging.info")
-def test_given_good_updated_input_entry_with_outdated_entry_in_mlwh_when_checking_entries_then_check_entry_updated_correctly(
+def test_given_good_outdated_entry_in_mlwh_when_checking_entries_then_check_entry_updated_correctly(
     mock_info,
     config,
     mlwh_database,

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -334,13 +334,9 @@ def test_given_bad_input_entry_without_location_when_making_sorting_entries_then
         call("Task successful!"),
     )
 
-    assert mock_error.has_calls(
-        call(
-            f"""
-                Found invalid entry: {TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["labwares"][0]}
-            """
-        )
-    )
+    bad_entry = TEST_ENTRIES["bad_input_entry_without_location"]["input_lw"]["labwares"][0]
+
+    assert mock_error.has_calls(call(f"Found invalid entry: {bad_entry}"))
 
 
 @pytest.mark.parametrize(
@@ -394,13 +390,9 @@ def test_given_bad_input_entry_without_audits_when_sorting_entries_then_check_en
         call("Task successful!"),
     )
 
-    assert mock_error.has_calls(
-        call(
-            f"""
-                Found invalid entry: {TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["labwares"][0]}
-            """
-        )
-    )
+    bad_entry = TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["labwares"][0]
+
+    assert mock_error.has_calls(call(f"Found invalid entry: {bad_entry}"))
 
 
 @pytest.mark.parametrize(
@@ -454,13 +446,9 @@ def test_given_bad_input_entry_without_location_without_audits_when_sorting_entr
         call("Task successful!"),
     )
 
-    assert mock_error.has_calls(
-        call(
-            f"""
-                Found invalid entry: {TEST_ENTRIES["bad_input_entry_without_location_without_audits"]["input_lw"]["labwares"][0]}
-            """
-        )
-    )
+    bad_entry = TEST_ENTRIES["bad_input_entry_without_location_without_audits"]["input_lw"]["labwares"][0]
+
+    assert mock_error.has_calls(call(f"Found invalid entry: {bad_entry}"))
 
 
 @pytest.mark.parametrize(
@@ -509,9 +497,9 @@ def test_given_mixed_entries_when_writing_entries_then_check_all_entries_process
     lw_coordinates_table,
 ):
     sync_changes_from_labwhere(config)
-    result = mlwh_database.execute_query("SELECT * FROM labware_location", {})
-    for result_index in range(len(result)):
-        actual_result = parse_entry(result[result_index], labware_location_columns)
+    good_entries = mlwh_database.execute_query("SELECT * FROM labware_location", {})
+    for result_index in range(len(good_entries)):
+        actual_result = parse_entry(good_entries[result_index], labware_location_columns)
         expected_result = TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][result_index]
 
         assert actual_result["id"] == expected_result["id"]
@@ -534,25 +522,11 @@ def test_given_mixed_entries_when_writing_entries_then_check_all_entries_process
         call("Task successful!"),
     )
 
+    bad_entries = TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"]
+
     assert mock_error.has_calls(
-        call(
-            f"""
-                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][0]}
-            """
-        ),
-        call(
-            f"""
-                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][1]}
-            """
-        ),
-        call(
-            f"""
-                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][2]}
-            """
-        ),
-        call(
-            f"""
-                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][3]}
-            """
-        ),
+        call(f"Found invalid entry: {bad_entries[0]}"),
+        call(f"Found invalid entry: {bad_entries[1]}"),
+        call(f"Found invalid entry: {bad_entries[2]}"),
+        call(f"Found invalid entry: {bad_entries[3]}"),
     )

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -1,0 +1,558 @@
+import pytest
+from unittest.mock import patch, call
+from janitor.tasks.labware_location.main import sync_changes_from_labwhere
+from janitor.helpers.mysql_helpers import parse_entry
+from tests.data.test_entries import TEST_ENTRIES
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["good_input_entry_with_location"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [TEST_ENTRIES["good_input_entry_with_location"]["input_lw"]["audits"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [TEST_ENTRIES["good_input_entry_with_location"]["input_lw"]["users"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [TEST_ENTRIES["good_input_entry_with_location"]["input_lw"]["locations"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [[]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+def test_given_good_input_entry_with_location_id_when_making_mlwh_entry_then_check_entry_written_correctly(
+    mock_info,
+    config,
+    mlwh_database,
+    mlwh_labware_locations_table,
+    labware_location_columns,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    result = mlwh_database.execute_query("SELECT * FROM labware_location", {})[0]
+    actual_result = parse_entry(result, labware_location_columns)
+    expected_result = TEST_ENTRIES["good_input_entry_with_location"]["output_mlwh_expected"]["labware_location"][0]
+
+    assert actual_result["id"] == expected_result["id"]
+    assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
+    assert actual_result["location_barcode"] == expected_result["location_barcode"]
+    assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
+    assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
+    assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
+    assert actual_result["lims_id"] == expected_result["lims_id"]
+    assert actual_result["stored_by"] == expected_result["stored_by"]
+    assert actual_result["stored_at"].minute == expected_result["stored_at"].minute
+    assert actual_result["created_at"].minute == expected_result["created_at"].minute
+    assert actual_result["updated_at"].minute == expected_result["updated_at"].minute
+
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 1 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["good_input_entry_with_coordinates"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [TEST_ENTRIES["good_input_entry_with_coordinates"]["input_lw"]["audits"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [TEST_ENTRIES["good_input_entry_with_coordinates"]["input_lw"]["users"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [TEST_ENTRIES["good_input_entry_with_coordinates"]["input_lw"]["locations"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [TEST_ENTRIES["good_input_entry_with_coordinates"]["input_lw"]["coordinates"]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+def test_given_good_input_entry_with_coordinate_id_when_making_mlwh_entry_then_check_entry_written_correctly(
+    mock_info,
+    config,
+    mlwh_database,
+    mlwh_labware_locations_table,
+    labware_location_columns,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    result = mlwh_database.execute_query("SELECT * FROM labware_location", {})[0]
+    actual_result = parse_entry(result, labware_location_columns)
+    expected_result = TEST_ENTRIES["good_input_entry_with_coordinates"]["output_mlwh_expected"]["labware_location"][0]
+
+    assert actual_result["id"] == expected_result["id"]
+    assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
+    assert actual_result["location_barcode"] == expected_result["location_barcode"]
+    assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
+    assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
+    assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
+    assert actual_result["lims_id"] == expected_result["lims_id"]
+    assert actual_result["stored_by"] == expected_result["stored_by"]
+    assert actual_result["stored_at"].minute == expected_result["stored_at"].minute
+    assert actual_result["created_at"].minute == expected_result["created_at"].minute
+    assert actual_result["updated_at"].minute == expected_result["updated_at"].minute
+
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 1 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["good_input_entry_with_two_audits"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [TEST_ENTRIES["good_input_entry_with_two_audits"]["input_lw"]["audits"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [TEST_ENTRIES["good_input_entry_with_two_audits"]["input_lw"]["users"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [TEST_ENTRIES["good_input_entry_with_two_audits"]["input_lw"]["locations"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [[]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_check_latest_audit_used(
+    mock_info,
+    config,
+    mlwh_database,
+    mlwh_labware_locations_table,
+    labware_location_columns,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    result = mlwh_database.execute_query("SELECT * FROM labware_location", {})[0]
+    actual_result = parse_entry(result, labware_location_columns)
+    expected_result = TEST_ENTRIES["good_input_entry_with_two_audits"]["output_mlwh_expected"]["labware_location"][0]
+
+    assert actual_result["id"] == expected_result["id"]
+    assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
+    assert actual_result["location_barcode"] == expected_result["location_barcode"]
+    assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
+    assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
+    assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
+    assert actual_result["lims_id"] == expected_result["lims_id"]
+    assert actual_result["stored_by"] == expected_result["stored_by"]
+    assert actual_result["stored_at"].minute == expected_result["stored_at"].minute
+    assert actual_result["created_at"].minute == expected_result["created_at"].minute
+    assert actual_result["updated_at"].minute == expected_result["updated_at"].minute
+
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 1 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [TEST_ENTRIES["good_input_entry_outdated_record_in_mlwh"]["input_mlwh"]["labware_location"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["good_input_entry_outdated_record_in_mlwh"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [TEST_ENTRIES["good_input_entry_outdated_record_in_mlwh"]["input_lw"]["audits"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [TEST_ENTRIES["good_input_entry_outdated_record_in_mlwh"]["input_lw"]["users"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [TEST_ENTRIES["good_input_entry_outdated_record_in_mlwh"]["input_lw"]["locations"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [[]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+def test_given_good_updated_input_entry_with_outdated_entry_in_mlwh_when_checking_entries_then_check_entry_updated_correctly(
+    mock_info,
+    config,
+    mlwh_database,
+    mlwh_labware_locations_table,
+    labware_location_columns,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    result = mlwh_database.execute_query("SELECT * FROM labware_location", {})[0]
+    actual_result = parse_entry(result, labware_location_columns)
+    expected_result = TEST_ENTRIES["good_input_entry_outdated_record_in_mlwh"]["output_mlwh_expected"][
+        "labware_location"
+    ][0]
+
+    assert actual_result["id"] == expected_result["id"]
+    assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
+    assert actual_result["location_barcode"] == expected_result["location_barcode"]
+    assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
+    assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
+    assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
+    assert actual_result["lims_id"] == expected_result["lims_id"]
+    assert actual_result["stored_by"] == expected_result["stored_by"]
+    assert actual_result["stored_at"].minute == expected_result["stored_at"].minute
+    assert actual_result["created_at"].minute == expected_result["created_at"].minute
+    assert actual_result["updated_at"].minute == expected_result["updated_at"].minute
+
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 1 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["bad_input_entry_without_location"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [TEST_ENTRIES["bad_input_entry_without_location"]["input_lw"]["audits"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [TEST_ENTRIES["bad_input_entry_without_location"]["input_lw"]["users"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [[]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("janitor.tasks.labware_location.main.logging.error")
+def test_given_bad_input_entry_without_location_when_making_sorting_entries_then_check_entry_filtered_out(
+    mock_info,
+    mock_error,
+    config,
+    mlwh_labware_locations_table,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 0 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+    assert mock_error.has_calls(
+        call(
+            f"""
+                Found invalid entry: {TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["labwares"][0]}
+            """
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["locations"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [[]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("janitor.tasks.labware_location.main.logging.error")
+def test_given_bad_input_entry_without_audits_when_sorting_entries_then_check_entry_filtered_out(
+    mock_info,
+    mock_error,
+    config,
+    mlwh_labware_locations_table,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 0 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+    assert mock_error.has_calls(
+        call(
+            f"""
+                Found invalid entry: {TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["labwares"][0]}
+            """
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["bad_input_entry_without_location_without_audits"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [[]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("janitor.tasks.labware_location.main.logging.error")
+def test_given_bad_input_entry_without_location_without_audits_when_sorting_entries_then_check_entry_filtered_out(
+    mock_info,
+    mock_error,
+    config,
+    mlwh_labware_locations_table,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 0 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+    assert mock_error.has_calls(
+        call(
+            f"""
+                Found invalid entry: {TEST_ENTRIES["bad_input_entry_without_location_without_audits"]["input_lw"]["labwares"][0]}
+            """
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "mlwh_labware_locations_table",
+    [[]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_labwares_table",
+    [TEST_ENTRIES["mixed_input_entries"]["input_lw"]["labwares"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_audits_table",
+    [TEST_ENTRIES["mixed_input_entries"]["input_lw"]["audits"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_users_table",
+    [TEST_ENTRIES["mixed_input_entries"]["input_lw"]["users"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_locations_table",
+    [TEST_ENTRIES["mixed_input_entries"]["input_lw"]["locations"]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "lw_coordinates_table",
+    [TEST_ENTRIES["mixed_input_entries"]["input_lw"]["coordinates"]],
+    indirect=True,
+)
+@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("janitor.tasks.labware_location.main.logging.error")
+def test_given_mixed_entries_when_writing_entries_then_check_all_entries_processed_correctly(
+    mock_info,
+    mock_error,
+    config,
+    mlwh_database,
+    mlwh_labware_locations_table,
+    labware_location_columns,
+    lw_labwares_table,
+    lw_audits_table,
+    lw_users_table,
+    lw_locations_table,
+    lw_coordinates_table,
+):
+    sync_changes_from_labwhere(config)
+    result = mlwh_database.execute_query("SELECT * FROM labware_location", {})
+    for result_index in range(len(result)):
+        actual_result = parse_entry(result[result_index], labware_location_columns)
+        expected_result = TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][result_index]
+
+        assert actual_result["id"] == expected_result["id"]
+        assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
+        assert actual_result["location_barcode"] == expected_result["location_barcode"]
+        assert actual_result["full_location_address"] == expected_result["full_location_address"]
+        assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
+        assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
+        assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
+        assert actual_result["lims_id"] == expected_result["lims_id"]
+        assert actual_result["stored_by"] == expected_result["stored_by"]
+        assert actual_result["stored_at"].minute == expected_result["stored_at"].minute
+        assert actual_result["created_at"].minute == expected_result["created_at"].minute
+        assert actual_result["updated_at"].minute == expected_result["updated_at"].minute
+
+    assert mock_info.has_calls(
+        call("Starting sync labware locations task..."),
+        call("Updating 4 rows..."),
+        call("Closing connections to databases..."),
+        call("Task successful!"),
+    )
+
+    assert mock_error.has_calls(
+        call(
+            f"""
+                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][0]}
+            """
+        ),
+        call(
+            f"""
+                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][1]}
+            """
+        ),
+        call(
+            f"""
+                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][2]}
+            """
+        ),
+        call(
+            f"""
+                Found invalid entry: {TEST_ENTRIES["mixed_input_entries"]["output_mlwh_expected"]["labware_location"][3]}
+            """
+        ),
+    )

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -1,18 +1,17 @@
 import pytest
 from unittest.mock import patch, call
 import mysql.connector
-from janitor.db.database import Database
 from janitor.tasks.labware_location.main import sync_changes_from_labwhere
 from janitor.helpers.mysql_helpers import parse_entry
 from tests.data.test_entries import TEST_ENTRIES
 
 
-@patch("janitor.tasks.labware_location.main.logging.info")
-@patch("janitor.tasks.labware_location.main.logging.error")
-def test_given_invalid_connection_when_connecting_to_db_then_check_error_messages_logged(mock_info, mock_error, config):
+@patch("logging.info")
+@patch("logging.error")
+def test_given_invalid_connection_when_connecting_to_db_then_check_error_messages_logged(
+    mock_info, mock_error, config, lw_database
+):
     with patch("mysql.connector.connect", side_effect=mysql.connector.Error()):
-        Database(config.LABWHERE_DB)
-
         assert mock_info.has_calls(
             call(f"Attempting to connect to {config.LABWHERE_DB['host']} on port {config.LABWHERE_DB['port']}..."),
         )
@@ -23,7 +22,7 @@ def test_given_invalid_connection_when_connecting_to_db_then_check_error_message
         )
 
 
-@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("logging.info")
 def test_given_valid_db_details_for_lw_database_when_connecting_to_db_then_check_connection_successful(
     mock_info, config, lw_database
 ):
@@ -33,7 +32,7 @@ def test_given_valid_db_details_for_lw_database_when_connecting_to_db_then_check
     )
 
 
-@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("logging.info")
 def test_given_valid_db_details_for_mlwh_database_when_connecting_to_db_then_check_connection_successful(
     mock_info, config, mlwh_database
 ):
@@ -73,7 +72,7 @@ def test_given_valid_db_details_for_mlwh_database_when_connecting_to_db_then_che
     [[]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("logging.info")
 def test_given_good_input_entry_with_location_id_when_making_mlwh_entry_then_check_entry_written_correctly(
     mock_info,
     config,
@@ -142,7 +141,7 @@ def test_given_good_input_entry_with_location_id_when_making_mlwh_entry_then_che
     [TEST_ENTRIES["good_input_entry_with_coordinates"]["input_lw"]["coordinates"]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("logging.info")
 def test_given_good_input_entry_with_coordinate_id_when_making_mlwh_entry_then_check_entry_written_correctly(
     mock_info,
     config,
@@ -211,7 +210,7 @@ def test_given_good_input_entry_with_coordinate_id_when_making_mlwh_entry_then_c
     [[]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("logging.info")
 def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_check_latest_audit_used(
     mock_info,
     config,
@@ -280,7 +279,7 @@ def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_chec
     [[]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
+@patch("logging.info")
 def test_given_good_outdated_entry_in_mlwh_when_checking_entries_then_check_entry_updated_correctly(
     mock_info,
     config,
@@ -351,8 +350,8 @@ def test_given_good_outdated_entry_in_mlwh_when_checking_entries_then_check_entr
     [[]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
-@patch("janitor.tasks.labware_location.main.logging.error")
+@patch("logging.info")
+@patch("logging.error")
 def test_given_bad_input_entry_without_location_when_making_sorting_entries_then_check_entry_filtered_out(
     mock_info,
     mock_error,
@@ -407,8 +406,8 @@ def test_given_bad_input_entry_without_location_when_making_sorting_entries_then
     [[]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
-@patch("janitor.tasks.labware_location.main.logging.error")
+@patch("logging.info")
+@patch("logging.error")
 def test_given_bad_input_entry_without_audits_when_sorting_entries_then_check_entry_filtered_out(
     mock_info,
     mock_error,
@@ -463,8 +462,8 @@ def test_given_bad_input_entry_without_audits_when_sorting_entries_then_check_en
     [[]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
-@patch("janitor.tasks.labware_location.main.logging.error")
+@patch("logging.info")
+@patch("logging.error")
 def test_given_bad_input_entry_without_location_without_audits_when_sorting_entries_then_check_entry_filtered_out(
     mock_info,
     mock_error,
@@ -519,8 +518,8 @@ def test_given_bad_input_entry_without_location_without_audits_when_sorting_entr
     [TEST_ENTRIES["mixed_input_entries"]["input_lw"]["coordinates"]],
     indirect=True,
 )
-@patch("janitor.tasks.labware_location.main.logging.info")
-@patch("janitor.tasks.labware_location.main.logging.error")
+@patch("logging.info")
+@patch("logging.error")
 def test_given_mixed_entries_when_writing_entries_then_check_all_entries_processed_correctly(
     mock_info,
     mock_error,

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -20,11 +20,6 @@ def test_given_valid_db_details_when_connecting_to_db_then_check_connection_succ
 
 
 @pytest.mark.parametrize(
-    "mlwh_labware_locations_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
     "lw_labwares_table",
     [TEST_ENTRIES["good_input_entry_with_location"]["input_lw"]["labwares"]],
     indirect=True,
@@ -42,11 +37,6 @@ def test_given_valid_db_details_when_connecting_to_db_then_check_connection_succ
 @pytest.mark.parametrize(
     "lw_locations_table",
     [TEST_ENTRIES["good_input_entry_with_location"]["input_lw"]["locations"]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_coordinates_table",
-    [[]],
     indirect=True,
 )
 @patch("logging.info")
@@ -88,11 +78,6 @@ def test_given_good_input_entry_with_location_id_when_making_mlwh_entry_then_che
     )
 
 
-@pytest.mark.parametrize(
-    "mlwh_labware_locations_table",
-    [[]],
-    indirect=True,
-)
 @pytest.mark.parametrize(
     "lw_labwares_table",
     [TEST_ENTRIES["good_input_entry_with_coordinates"]["input_lw"]["labwares"]],
@@ -158,11 +143,6 @@ def test_given_good_input_entry_with_coordinate_id_when_making_mlwh_entry_then_c
 
 
 @pytest.mark.parametrize(
-    "mlwh_labware_locations_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
     "lw_labwares_table",
     [TEST_ENTRIES["good_input_entry_with_two_audits"]["input_lw"]["labwares"]],
     indirect=True,
@@ -180,11 +160,6 @@ def test_given_good_input_entry_with_coordinate_id_when_making_mlwh_entry_then_c
 @pytest.mark.parametrize(
     "lw_locations_table",
     [TEST_ENTRIES["good_input_entry_with_two_audits"]["input_lw"]["locations"]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_coordinates_table",
-    [[]],
     indirect=True,
 )
 @patch("logging.info")
@@ -251,11 +226,6 @@ def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_chec
     [TEST_ENTRIES["good_input_entry_outdated_record_in_mlwh"]["input_lw"]["locations"]],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "lw_coordinates_table",
-    [[]],
-    indirect=True,
-)
 @patch("logging.info")
 def test_given_good_outdated_entry_in_mlwh_when_checking_entries_then_check_entry_updated_correctly(
     mock_info,
@@ -298,11 +268,6 @@ def test_given_good_outdated_entry_in_mlwh_when_checking_entries_then_check_entr
 
 
 @pytest.mark.parametrize(
-    "mlwh_labware_locations_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
     "lw_labwares_table",
     [TEST_ENTRIES["bad_input_entry_without_location"]["input_lw"]["labwares"]],
     indirect=True,
@@ -315,16 +280,6 @@ def test_given_good_outdated_entry_in_mlwh_when_checking_entries_then_check_entr
 @pytest.mark.parametrize(
     "lw_users_table",
     [TEST_ENTRIES["bad_input_entry_without_location"]["input_lw"]["users"]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_locations_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_coordinates_table",
-    [[]],
     indirect=True,
 )
 @patch("logging.info")
@@ -354,33 +309,13 @@ def test_given_bad_input_entry_without_location_when_making_sorting_entries_then
 
 
 @pytest.mark.parametrize(
-    "mlwh_labware_locations_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
     "lw_labwares_table",
     [TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["labwares"]],
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "lw_audits_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_users_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
     "lw_locations_table",
     [TEST_ENTRIES["bad_input_entry_without_audits"]["input_lw"]["locations"]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_coordinates_table",
-    [[]],
     indirect=True,
 )
 @patch("logging.info")
@@ -410,33 +345,8 @@ def test_given_bad_input_entry_without_audits_when_sorting_entries_then_check_en
 
 
 @pytest.mark.parametrize(
-    "mlwh_labware_locations_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
     "lw_labwares_table",
     [TEST_ENTRIES["bad_input_entry_without_location_without_audits"]["input_lw"]["labwares"]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_audits_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_users_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_locations_table",
-    [[]],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "lw_coordinates_table",
-    [[]],
     indirect=True,
 )
 @patch("logging.info")
@@ -465,11 +375,6 @@ def test_given_bad_input_entry_without_location_without_audits_when_sorting_entr
     assert mock_error.has_calls(call(f"Found invalid entry: {bad_entry}"))
 
 
-@pytest.mark.parametrize(
-    "mlwh_labware_locations_table",
-    [[]],
-    indirect=True,
-)
 @pytest.mark.parametrize(
     "lw_labwares_table",
     [TEST_ENTRIES["mixed_input_entries"]["input_lw"]["labwares"]],

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,0 +1,51 @@
+from typing import TypedDict, Optional
+from datetime import datetime
+
+
+class LabwaresTableEntry(TypedDict):
+    id: int
+    barcode: str
+    location_id: Optional[int]
+    coordinate_id: Optional[int]
+
+
+class AuditsTableEntry(TypedDict):
+    id: int
+    auditable_id: int
+    auditable_type: str
+    user_id: int
+    updated_at: datetime
+
+
+class UsersTableEntry(TypedDict):
+    id: int
+    login: str
+
+
+class LocationsTableEntry(TypedDict):
+    id: int
+    barcode: str
+    parentage: str
+
+
+class CoordinatesTableEntry(TypedDict):
+    id: int
+    position: int
+    row: int
+    column: int
+    location_id: int
+
+
+class LabwareLocationTableEntry(TypedDict):
+    id: int
+    labware_barcode: str
+    location_barcode: str
+    full_location_address: str
+    coordinate_position: int
+    coordinate_row: int
+    coordinate_column: int
+    lims_id: str
+    stored_by: str
+    stored_at: datetime
+    created_at: datetime
+    updated_at: datetime

--- a/tests/types.py
+++ b/tests/types.py
@@ -41,9 +41,9 @@ class LabwareLocationTableEntry(TypedDict):
     labware_barcode: str
     location_barcode: str
     full_location_address: str
-    coordinate_position: int
-    coordinate_row: int
-    coordinate_column: int
+    coordinate_position: Optional[int]
+    coordinate_row: Optional[int]
+    coordinate_column: Optional[int]
     lims_id: str
     stored_by: str
     stored_at: datetime


### PR DESCRIPTION
Closes https://github.com/sanger/janitor/issues/1

Changes proposed in this pull request:

* This pull request will add unit tests for syncing labware locations. The tests are in the `tests` directory.
* The unit tests check to see that for given entries in the LabWhere database tables, the application produces the correct results to write to the MLWH `labware_location` table. The input entries and expected output entries are defined in `tests/data/test_entries.py`.
* The unit tests also check that the correct error messages get logged if there are issues such as being unable to connect to the databases.
