### PR TITLE
DPL-773-1 Rename master to main in workflow files

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - main
 
 env:
   IMAGE_NAME: ${{ github.repository }}/${{ github.event.repository.name }}
@@ -59,7 +59,7 @@ jobs:
         with:
           name: ${{ env.RELEASE_NAME }}
           tag: ${{ env.RELEASE_TAG }}
-          prerelease: ${{ !(github.ref == 'refs/heads/master') }}
+          prerelease: ${{ !(github.ref == 'refs/heads/main') }}
           commit: ${{ github.sha }}
 
       - name: Login to registry

--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -4,7 +4,7 @@ name: Check release version
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - develop-*
       - develop
-      - master
+      - main
   pull_request:
     branches:
       - develop-*
       - develop
-      - master
+      - main
 
 env:
   SETTINGS_MODULE: janitor.config.test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop-*, develop, master ]
+    branches: [ develop-*, develop, main ]
     paths-ignore:
       - "README.md"
   pull_request:

--- a/.github/workflows/docker_dispatch.yml
+++ b/.github/workflows/docker_dispatch.yml
@@ -27,7 +27,7 @@ jobs:
           -u ${{ github.actor }}
           -p ${{ secrets.GITHUB_TOKEN }}
           docker.pkg.github.com
-      - name: Publish image with image tag being either develop/master/<tag_name>
+      - name: Publish image with image tag being either develop/main/<tag_name>
         run: >-
           docker push
           docker.pkg.github.com/${IMAGE_NAME}:${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
Closes #1 

Changes proposed in this pull request:

* Change `master` to `main` in workflow files to match repo branch name
