### PR TITLE
DPL-773-1 Remove job interval from query

### DIFF
--- a/janitor/config/defaults.py
+++ b/janitor/config/defaults.py
@@ -7,7 +7,6 @@ from .logging import *  # noqa: F401, F403
 LOCALHOST = os.environ.get("LOCALHOST", "127.0.0.1")
 
 SYNC_JOB_INTERVAL_SEC = 300
-SYNC_JOB_OVERLAP_SEC = 10
 
 LABWHERE_DB = DbConnectionDetails(
     db_name="labwhere_prod",

--- a/janitor/config/test.py
+++ b/janitor/config/test.py
@@ -5,7 +5,6 @@ from .logging import LOGGING
 
 # setting here will overwrite those in 'defaults.py'
 SYNC_JOB_INTERVAL_SEC = 300
-SYNC_JOB_OVERLAP_SEC = 10
 
 LABWHERE_DB = DbConnectionDetails(
     db_name="janitor_tests_lw_input",

--- a/janitor/db/database.py
+++ b/janitor/db/database.py
@@ -40,6 +40,8 @@ class Database:
             if connection.is_connected():
                 logger.info(f"MySQL connection to {self.creds['db_name']} successful!")
                 self._connection = cast(MySQLConnectionAbstract, connection)
+            else:
+                logger.error(f"MySQL connection to {self.creds['db_name']} failed!")
 
         except mysql.Error as e:
             logger.error(f"Exception on connecting to MySQL database: {e}")

--- a/janitor/db/database.py
+++ b/janitor/db/database.py
@@ -71,6 +71,7 @@ class Database:
                 with self.connection.cursor() as cursor:
                     cursor.execute(query, params)
                     results = cursor.fetchall()
+                    self.connection.commit()
             except Exception as e:
                 logger.error(f"Exception on executing query: {e}")
 

--- a/janitor/tasks/labware_location/main.py
+++ b/janitor/tasks/labware_location/main.py
@@ -1,9 +1,14 @@
 import logging
 import time
+from datetime import datetime
 
 from janitor.db.database import Database
 from janitor.helpers.mlwh_helpers import sort_results
-from janitor.tasks.labware_location.sql_queries.sql_queries import GET_LOCATIONS_QUERY, WRITE_TO_LABWARE_LOCATION_QUERY
+from janitor.tasks.labware_location.sql_queries.sql_queries import (
+    GET_LATEST_TIMESTAMP_QUERY,
+    GET_LOCATIONS_QUERY,
+    WRITE_TO_LABWARE_LOCATION_QUERY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,10 +18,15 @@ def sync_changes_from_labwhere(config):
     logger.info("Starting sync labware locations task...")
     db_labwhere = Database(config.LABWHERE_DB)
     db_mlwh = Database(config.MLWH_DB)
-    sync_job_interval = config.SYNC_JOB_INTERVAL_SEC + config.SYNC_JOB_OVERLAP_SEC
+
+    latest_timestamp = db_mlwh.execute_query(GET_LATEST_TIMESTAMP_QUERY, {})[0][0]
+
+    if not latest_timestamp:
+        latest_timestamp = datetime.min
+
     results = db_labwhere.execute_query(
         GET_LOCATIONS_QUERY,
-        {"interval": str(sync_job_interval)},
+        {"latest_timestamp": latest_timestamp},
     )
 
     mlwh_entries, invalid_entries = sort_results(results)

--- a/janitor/tasks/labware_location/main.py
+++ b/janitor/tasks/labware_location/main.py
@@ -19,7 +19,11 @@ def sync_changes_from_labwhere(config):
     db_labwhere = Database(config.LABWHERE_DB)
     db_mlwh = Database(config.MLWH_DB)
 
-    latest_timestamp = db_mlwh.execute_query(GET_LATEST_TIMESTAMP_QUERY, {})[0][0]
+    try:
+        latest_timestamp = db_mlwh.execute_query(GET_LATEST_TIMESTAMP_QUERY, {})[0][0]
+    except Exception as e:
+        logger.error(f"Exception on querying labware_location: {e}")
+        raise
 
     if not latest_timestamp:
         latest_timestamp = datetime.min

--- a/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
+++ b/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
@@ -29,4 +29,4 @@ LEFT JOIN audits audits_b ON
 	AND audits.id < audits_b.id
 WHERE
 	audits_b.updated_at IS NULL
-	AND audits.updated_at > NOW() - INTERVAL %(interval)s SECOND
+	AND audits.updated_at >= %(latest_timestamp)s;

--- a/janitor/tasks/labware_location/sql_queries/get_latest_timestamp.sql
+++ b/janitor/tasks/labware_location/sql_queries/get_latest_timestamp.sql
@@ -1,0 +1,1 @@
+SELECT MAX(updated_at) FROM labware_location;

--- a/janitor/tasks/labware_location/sql_queries/sql_queries.py
+++ b/janitor/tasks/labware_location/sql_queries/sql_queries.py
@@ -8,5 +8,8 @@ SQL_FOLDER_PATH = Path("./janitor/tasks/labware_location/sql_queries")
 GET_LOCATIONS_FILE = "get_labware_locations.sql"
 GET_LOCATIONS_QUERY = load_query(SQL_FOLDER_PATH / GET_LOCATIONS_FILE)
 
+GET_LATEST_TIMESTAMP_FILE = "get_latest_timestamp.sql"
+GET_LATEST_TIMESTAMP_QUERY = load_query(SQL_FOLDER_PATH / GET_LATEST_TIMESTAMP_FILE)
+
 WRITE_TO_LABWARE_LOCATION_FILE = "write_to_labware_locations.sql"
 WRITE_TO_LABWARE_LOCATION_QUERY = load_query(SQL_FOLDER_PATH / WRITE_TO_LABWARE_LOCATION_FILE)

--- a/tests/data/entries.py
+++ b/tests/data/entries.py
@@ -171,8 +171,8 @@ good_input_entry_outdated_record_in_mlwh_input: Dict[str, Any] = {
             lims_id="LabWhere",
             stored_by="user3",
             stored_at=get_time(delta_mins=4),
-            created_at=get_time(delta_mins=0),
-            updated_at=get_time(delta_mins=0),
+            created_at=get_time(delta_mins=4),
+            updated_at=get_time(delta_mins=4),
         )
     ],
 }
@@ -190,7 +190,7 @@ good_input_entry_outdated_record_in_mlwh_output: Dict[str, Any] = {
             lims_id="LabWhere",
             stored_by="user4",
             stored_at=get_time(delta_mins=2),
-            created_at=get_time(delta_mins=0),
+            created_at=get_time(delta_mins=4),
             updated_at=get_time(delta_mins=0),
         )
     ]

--- a/tests/db/test_database.py
+++ b/tests/db/test_database.py
@@ -31,6 +31,18 @@ def test_given_invalid_connection_when_closing_connection_then_check_error_messa
 
 
 @patch("logging.error")
+def test_given_valid_connection_details_when_connection_fails_then_check_error_message_logged(mock_error, config):
+    with patch("mysql.connector.connect") as mock_connect:
+        mock_connect.return_value.is_connected.return_value = False
+        test_db = Database(test_config)
+
+        assert test_db.connection is None
+        assert mock_error.has_calls(
+            call(f"MySQL connection to {config.MLWH_DB['db_name']} failed!"),
+        )
+
+
+@patch("logging.error")
 def test_given_error_when_executing_sql_query_then_check_error_message_logged(mock_error):
     with patch("mysql.connector.cursor") as mock_cursor:
         mock_cursor.return_value.execute.return_value = AttributeError("Database not connected")

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -116,7 +116,9 @@ def write_to_tables(
 
 
 @patch("logging.info")
-def test_given_valid_db_details_when_connecting_to_db_then_check_connection_successful(mock_info, config):
+def test_given_valid_db_details_when_connecting_to_db_then_check_connection_successful(
+    mock_info, config, mlwh_database
+):
     sync_changes_from_labwhere(config)
 
     assert mock_info.has_calls(

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -148,7 +148,7 @@ def test_given_valid_connection_and_deleting_db_when_attempting_sync_then_check_
 def test_given_valid_connection_and_deleting_labware_location_table_when_attempting_sync_then_check_exception_raised(
     mock_error, config, mlwh_database
 ):
-    mlwh_database.execute_query(f"DROP TABLE labware_location", {})
+    mlwh_database.execute_query("DROP TABLE labware_location", {})
     with pytest.raises(IndexError) as error:
         sync_changes_from_labwhere(config)
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove job interval from SQL query which gets updated records from LabWhere database
* Add query to get latest update timestamp from `labware_location` i.e. the last time the table was synchronised
* Use latest timestamp as new time to get updated records (all records which were updated since the last time the table was synchronised)
