### PR TITLE
DPL-773 Fix commands out of sync error

### DIFF
--- a/janitor/db/database.py
+++ b/janitor/db/database.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class Database:
-    def __init__(self, creds: DbConnectionDetails, autocommit=True):
+    def __init__(self, creds: DbConnectionDetails, autocommit: bool = True):
         """Open a MySQL connection to read and write data to tables in a database.
 
         Arguments:

--- a/janitor/db/database.py
+++ b/janitor/db/database.py
@@ -12,13 +12,14 @@ logger = logging.getLogger(__name__)
 
 
 class Database:
-    def __init__(self, creds: DbConnectionDetails):
+    def __init__(self, creds: DbConnectionDetails, autocommit=True):
         """Open a MySQL connection to read and write data to tables in a database.
 
         Arguments:
             creds {DbConnectionDetails}: details for database connection
         """
         self.creds = creds
+        self.autocommit = autocommit
         self._connection: Optional[MySQLConnectionAbstract] = None
 
     @property
@@ -36,6 +37,7 @@ class Database:
                 database=self.creds["db_name"],
                 username=self.creds["username"],
                 password=self.creds["password"],
+                autocommit=self.autocommit,
             )
 
             if connection.is_connected():
@@ -79,7 +81,6 @@ class Database:
             with self.connection.cursor() as cursor:
                 cursor.execute(query, params)
                 results = cursor.fetchall()
-                self.connection.commit()
         except Exception as e:
             logger.error(f"Exception on executing query: {e}")
 

--- a/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
+++ b/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
@@ -29,6 +29,6 @@ LEFT JOIN audits audits_b ON
 	AND audits.id < audits_b.id
 WHERE
 	audits_b.updated_at IS NULL
-	AND audits.updated_at >= %(latest_timestamp)s;
+	AND audits.updated_at >= %(latest_timestamp)s
 ORDER BY
 	stored_at ASC;

--- a/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
+++ b/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
@@ -31,4 +31,4 @@ WHERE
 	audits_b.updated_at IS NULL
 	AND audits.updated_at >= %(latest_timestamp)s;
 ORDER BY
-	stored_at ASC
+	stored_at ASC;

--- a/janitor/tasks/labware_location/sql_queries/write_to_labware_locations.sql
+++ b/janitor/tasks/labware_location/sql_queries/write_to_labware_locations.sql
@@ -22,4 +22,4 @@ ON DUPLICATE KEY UPDATE
     lims_id = VALUES(lims_id),
     stored_by = VALUES(stored_by),
     stored_at = VALUES(stored_at),
-    updated_at = VALUES(updated_at)
+    updated_at = VALUES(updated_at);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging.config
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 
@@ -9,6 +10,18 @@ from janitor.types import DbConnectionDetails
 
 CONFIG = get_config("janitor.config.test")
 logging.config.dictConfig(CONFIG.LOGGING)
+
+
+@pytest.fixture
+def mock_info():
+    with patch("logging.info") as mock_logging_info:
+        yield mock_logging_info
+
+
+@pytest.fixture
+def mock_error():
+    with patch("logging.error") as mock_logging_error:
+        yield mock_logging_error
 
 
 @pytest.fixture

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from unittest.mock import call, patch
+from unittest.mock import call
 
 import pytest
 from mysql.connector.errors import DatabaseError
@@ -106,7 +106,6 @@ def write_to_tables(
         )
 
 
-@patch("logging.info")
 def test_given_valid_db_details_when_connecting_to_db_then_check_connection_successful(
     mock_info, config, mlwh_database
 ):
@@ -120,7 +119,6 @@ def test_given_valid_db_details_when_connecting_to_db_then_check_connection_succ
     )
 
 
-@patch("logging.error")
 def test_given_valid_connection_and_deleting_db_when_attempting_sync_then_check_exception_raised(
     mock_error, config, mlwh_database
 ):
@@ -133,7 +131,6 @@ def test_given_valid_connection_and_deleting_db_when_attempting_sync_then_check_
     )
 
 
-@patch("logging.error")
 def test_given_valid_connection_and_deleting_labware_location_table_when_attempting_sync_then_check_exception_raised(
     mock_error, config, mlwh_database
 ):
@@ -146,9 +143,8 @@ def test_given_valid_connection_and_deleting_labware_location_table_when_attempt
     )
 
 
-@patch("logging.info")
 def test_given_good_input_entry_with_location_when_making_mlwh_entry_then_check_entry_written_correctly(
-    mock_info, config, lw_database, mlwh_database, freezer
+    mock_info, mock_error, config, lw_database, mlwh_database, freezer
 ):
     write_to_tables(
         lw_database,
@@ -184,10 +180,11 @@ def test_given_good_input_entry_with_location_when_making_mlwh_entry_then_check_
         call("Task successful!"),
     )
 
+    assert mock_error.call_count == 0
 
-@patch("logging.info")
+
 def test_given_good_input_entry_with_coordinates_when_making_mlwh_entry_then_check_entry_written_correctly(
-    mock_info, config, lw_database, mlwh_database, freezer
+    mock_info, mock_error, config, lw_database, mlwh_database, freezer
 ):
     write_to_tables(
         lw_database,
@@ -224,10 +221,11 @@ def test_given_good_input_entry_with_coordinates_when_making_mlwh_entry_then_che
         call("Task successful!"),
     )
 
+    assert mock_error.call_count == 0
 
-@patch("logging.info")
+
 def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_check_latest_audit_used(
-    mock_info, config, lw_database, mlwh_database, freezer
+    mock_info, mock_error, config, lw_database, mlwh_database, freezer
 ):
     write_to_tables(
         lw_database,
@@ -263,10 +261,11 @@ def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_chec
         call("Task successful!"),
     )
 
+    assert mock_error.call_count == 0
 
-@patch("logging.info")
+
 def test_given_good_input_entry_outdated_record_in_mlwh_when_checking_entries_then_check_entry_updated_correctly(
-    mock_info, config, lw_database, mlwh_database, freezer
+    mock_info, mock_error, config, lw_database, mlwh_database, freezer
 ):
     write_to_tables(
         lw_database,
@@ -303,9 +302,9 @@ def test_given_good_input_entry_outdated_record_in_mlwh_when_checking_entries_th
         call("Task successful!"),
     )
 
+    assert mock_error.call_count == 0
 
-@patch("logging.info")
-@patch("logging.error")
+
 def test_given_bad_input_entry_without_location_when_making_sorting_entries_then_check_entry_filtered_out(
     mock_info, mock_error, config, lw_database, mlwh_database
 ):
@@ -330,8 +329,6 @@ def test_given_bad_input_entry_without_location_when_making_sorting_entries_then
     )
 
 
-@patch("logging.info")
-@patch("logging.error")
 def test_given_bad_input_entry_without_audits_when_sorting_entries_then_check_entry_filtered_out(
     mock_info, mock_error, config, lw_database, mlwh_database
 ):
@@ -355,8 +352,6 @@ def test_given_bad_input_entry_without_audits_when_sorting_entries_then_check_en
     )
 
 
-@patch("logging.info")
-@patch("logging.error")
 def test_given_bad_input_entry_without_location_without_audits_when_sorting_entries_then_check_entry_filtered_out(
     mock_info, mock_error, config, lw_database, mlwh_database
 ):
@@ -381,8 +376,6 @@ def test_given_bad_input_entry_without_location_without_audits_when_sorting_entr
     )
 
 
-@patch("logging.info")
-@patch("logging.error")
 def test_given_mixed_entries_when_writing_entries_then_check_all_entries_processed_correctly(
     mock_info, mock_error, config, lw_database, mlwh_database, freezer
 ):


### PR DESCRIPTION
Changes proposed in this pull request:

* Add autocommit to database connection. When executing a query, even if just reading, MySQL starts a transaction then when trying to write to database, an error is logged reporting commands out of sync. Manually closing the cursor does not seem to fix this, adding autocommit does
* Add Pytest fixtures for logging info and error
* Add final semi colon and new lines to SQL queries
