### PR TITLE
DPL-1017 Add location name to labware location table

### DIFF
--- a/janitor/helpers/mlwh_helpers.py
+++ b/janitor/helpers/mlwh_helpers.py
@@ -10,8 +10,10 @@ labware_labwhere_columns = [
     "labware_barcode",
     "unordered_barcode",
     "unordered_full",
+    "unordered_name",
     "ordered_barcode",
     "ordered_full",
+    "ordered_name",
     "coordinate_position",
     "coordinate_row",
     "coordinate_column",
@@ -32,6 +34,7 @@ def make_mlwh_entry(entry: LabwareLabwhereEntry) -> LabwareMLWHEntry:
     labware_barcode = entry["labware_barcode"]
     location_barcode = entry["unordered_barcode"]
     full_location_address = entry["unordered_full"]
+    location_name = entry["unordered_name"]
     coordinate_position = entry["coordinate_position"]
     coordinate_row = entry["coordinate_row"]
     coordinate_column = entry["coordinate_column"]
@@ -44,11 +47,13 @@ def make_mlwh_entry(entry: LabwareLabwhereEntry) -> LabwareMLWHEntry:
     if entry["ordered_barcode"] is not None:
         location_barcode = entry["ordered_barcode"]
         full_location_address = entry["ordered_full"]
+        location_name = entry["ordered_name"]
 
     return {
         "labware_barcode": labware_barcode,
         "location_barcode": location_barcode,
         "full_location_address": full_location_address,
+        "location_name": location_name,
         "coordinate_position": coordinate_position,
         "coordinate_row": coordinate_row,
         "coordinate_column": coordinate_column,

--- a/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
+++ b/janitor/tasks/labware_location/sql_queries/get_labware_locations.sql
@@ -1,34 +1,31 @@
 SELECT
-	lw.id,
-	lw.barcode AS labware_barcode,
-	loc1.barcode AS unordered_barcode,
-	loc1.parentage AS unordered_full,
-	loc2.barcode AS ordered_barcode,
-	loc2.parentage AS ordered_full,
-	coords.position AS coordinate_position,
-	coords.row AS coordinate_row,
-	coords.column AS coordinate_column,
-	users.login AS stored_by,
-	audits.updated_at AS stored_at
-FROM
-	labwares lw
-LEFT JOIN locations loc1 ON
-	lw.location_id = loc1.id
-LEFT JOIN coordinates coords ON
-	lw.coordinate_id = coords.id
-LEFT JOIN locations loc2 ON
-	coords.location_id = loc2.id
-LEFT JOIN audits ON
-	lw.id = audits.auditable_id
-	AND audits.auditable_type = "Labware"
-LEFT JOIN users ON
-	audits.user_id = users.id
-LEFT JOIN audits audits_b ON
-	audits.auditable_id = audits_b.auditable_id
-	AND audits_b.auditable_type = "Labware"
-	AND audits.id < audits_b.id
-WHERE
-	audits_b.updated_at IS NULL
-	AND audits.updated_at >= %(latest_timestamp)s
-ORDER BY
-	stored_at ASC;
+  lw.id,
+  lw.barcode labware_barcode,
+  loc1.barcode unordered_barcode,
+  loc1.parentage unordered_full,
+  loc1.name unordered_name,
+  loc2.barcode ordered_barcode,
+  loc2.parentage ordered_full,
+  loc2.name ordered_name,
+  coords.position coordinate_position,
+  coords.row coordinate_row,
+  coords.column coordinate_column,
+  users.login stored_by,
+  audits.updated_at stored_at
+FROM labwares lw
+LEFT JOIN locations loc1 ON lw.location_id = loc1.id
+LEFT JOIN coordinates coords ON lw.coordinate_id = coords.id
+LEFT JOIN locations loc2 ON coords.location_id = loc2.id
+LEFT JOIN audits
+  ON lw.id = audits.auditable_id
+  AND audits.auditable_type = "Labware"
+LEFT JOIN users ON audits.user_id = users.id
+LEFT JOIN audits audits_b
+  ON audits.auditable_id = audits_b.auditable_id
+  AND audits_b.auditable_type = "Labware"
+  AND audits.id < audits_b.id
+
+WHERE audits_b.updated_at IS NULL
+AND audits.updated_at >= %(latest_timestamp)s
+
+ORDER BY stored_at ASC;

--- a/janitor/tasks/labware_location/sql_queries/write_to_labware_locations.sql
+++ b/janitor/tasks/labware_location/sql_queries/write_to_labware_locations.sql
@@ -2,6 +2,7 @@ INSERT INTO labware_location (
     labware_barcode,
     location_barcode,
     full_location_address,
+    location_name,
     coordinate_position,
     coordinate_row,
     coordinate_column,
@@ -12,10 +13,11 @@ INSERT INTO labware_location (
     updated_at
 )
 VALUES
-    (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE
     location_barcode = VALUES(location_barcode),
     full_location_address = VALUES(full_location_address),
+    location_name = VALUES(location_name),
     coordinate_position = VALUES(coordinate_position),
     coordinate_row = VALUES(coordinate_row),
     coordinate_column = VALUES(coordinate_column),

--- a/janitor/types.py
+++ b/janitor/types.py
@@ -38,9 +38,9 @@ class LabwareLabwhereEntry(TypedDict):
 
 class LabwareMLWHEntry(TypedDict):
     labware_barcode: str
-    location_barcode: str
-    full_location_address: str
-    location_name: str
+    location_barcode: Optional[str]
+    full_location_address: Optional[str]
+    location_name: Optional[str]
     coordinate_position: Optional[int]
     coordinate_row: Optional[int]
     coordinate_column: Optional[int]

--- a/janitor/types.py
+++ b/janitor/types.py
@@ -25,8 +25,10 @@ class LabwareLabwhereEntry(TypedDict):
     labware_barcode: str
     unordered_barcode: Optional[str]
     unordered_full: Optional[str]
+    unordered_name: Optional[str]
     ordered_barcode: Optional[str]
     ordered_full: Optional[str]
+    ordered_name: Optional[str]
     coordinate_position: Optional[int]
     coordinate_row: Optional[int]
     coordinate_column: Optional[int]
@@ -38,6 +40,7 @@ class LabwareMLWHEntry(TypedDict):
     labware_barcode: str
     location_barcode: Optional[str]
     full_location_address: Optional[str]
+    location_name: Optional[str]
     coordinate_position: Optional[int]
     coordinate_row: Optional[int]
     coordinate_column: Optional[int]

--- a/janitor/types.py
+++ b/janitor/types.py
@@ -38,9 +38,9 @@ class LabwareLabwhereEntry(TypedDict):
 
 class LabwareMLWHEntry(TypedDict):
     labware_barcode: str
-    location_barcode: Optional[str]
-    full_location_address: Optional[str]
-    location_name: Optional[str]
+    location_barcode: str
+    full_location_address: str
+    location_name: str
     coordinate_position: Optional[int]
     coordinate_row: Optional[int]
     coordinate_column: Optional[int]

--- a/tests/data/entries.py
+++ b/tests/data/entries.py
@@ -40,7 +40,12 @@ class Entries:
             ],
             "users": [UsersTableEntry(id=1, login="user1")],
             "locations": [
-                LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1")
+                LocationsTableEntry(
+                    id=1,
+                    barcode="unordered_location1",
+                    parentage="PARENT / unordered_location1",
+                    name="unordered_location1",
+                )
             ],
         }
 
@@ -53,6 +58,7 @@ class Entries:
                     labware_barcode="labware1",
                     location_barcode="unordered_location1",
                     full_location_address="PARENT / unordered_location1",
+                    location_name="unordered_location1",
                     coordinate_position=None,
                     coordinate_row=None,
                     coordinate_column=None,
@@ -80,7 +86,9 @@ class Entries:
             ],
             "users": [UsersTableEntry(id=2, login="user2")],
             "locations": [
-                LocationsTableEntry(id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2")
+                LocationsTableEntry(
+                    id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2", name="ordered_location2"
+                )
             ],
             "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
         }
@@ -94,6 +102,7 @@ class Entries:
                     labware_barcode="labware2",
                     location_barcode="ordered_location2",
                     full_location_address="PARENT / ordered_location2",
+                    location_name="ordered_location2",
                     coordinate_position=1,
                     coordinate_row=1,
                     coordinate_column=1,
@@ -128,7 +137,12 @@ class Entries:
             ],
             "users": [UsersTableEntry(id=3, login="user3"), UsersTableEntry(id=4, login="user4")],
             "locations": [
-                LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3")
+                LocationsTableEntry(
+                    id=3,
+                    barcode="unordered_location3",
+                    parentage="PARENT / unordered_location3",
+                    name="unordered_location3",
+                )
             ],
         }
 
@@ -141,6 +155,7 @@ class Entries:
                     labware_barcode="labware3",
                     location_barcode="unordered_location3",
                     full_location_address="PARENT / unordered_location3",
+                    location_name="unordered_location3",
                     coordinate_position=None,
                     coordinate_row=None,
                     coordinate_column=None,
@@ -175,8 +190,18 @@ class Entries:
             ],
             "users": [UsersTableEntry(id=3, login="user3"), UsersTableEntry(id=4, login="user4")],
             "locations": [
-                LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3"),
-                LocationsTableEntry(id=4, barcode="unordered_location4", parentage="PARENT / unordered_location4"),
+                LocationsTableEntry(
+                    id=3,
+                    barcode="unordered_location3",
+                    parentage="PARENT / unordered_location3",
+                    name="unordered_location3",
+                ),
+                LocationsTableEntry(
+                    id=4,
+                    barcode="unordered_location4",
+                    parentage="PARENT / unordered_location4",
+                    name="unordered_location4",
+                ),
             ],
             "labware_location": [
                 LabwareLocationTableEntry(
@@ -184,6 +209,7 @@ class Entries:
                     labware_barcode="labware4",
                     location_barcode="unordered_location3",
                     full_location_address="PARENT / unordered_location3",
+                    location_name="unordered_location3",
                     coordinate_position=None,
                     coordinate_row=None,
                     coordinate_column=None,
@@ -205,6 +231,7 @@ class Entries:
                     labware_barcode="labware4",
                     location_barcode="unordered_location4",
                     full_location_address="PARENT / unordered_location4",
+                    location_name="unordered_location4",
                     coordinate_position=None,
                     coordinate_row=None,
                     coordinate_column=None,
@@ -307,10 +334,27 @@ class Entries:
                 UsersTableEntry(id=7, login="user7"),
             ],
             "locations": [
-                LocationsTableEntry(id=1, barcode="unordered_location1", parentage="PARENT / unordered_location1"),
-                LocationsTableEntry(id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2"),
-                LocationsTableEntry(id=3, barcode="unordered_location3", parentage="PARENT / unordered_location3"),
-                LocationsTableEntry(id=4, barcode="unordered_location4", parentage="PARENT / unordered_location4"),
+                LocationsTableEntry(
+                    id=1,
+                    barcode="unordered_location1",
+                    parentage="PARENT / unordered_location1",
+                    name="unordered_location1",
+                ),
+                LocationsTableEntry(
+                    id=2, barcode="ordered_location2", parentage="PARENT / ordered_location2", name="ordered_location2"
+                ),
+                LocationsTableEntry(
+                    id=3,
+                    barcode="unordered_location3",
+                    parentage="PARENT / unordered_location3",
+                    name="unordered_location3",
+                ),
+                LocationsTableEntry(
+                    id=4,
+                    barcode="unordered_location4",
+                    parentage="PARENT / unordered_location4",
+                    name="unordered_location4",
+                ),
             ],
             "coordinates": [CoordinatesTableEntry(id=2, position=1, row=1, column=1, location_id=2)],
         }
@@ -324,6 +368,7 @@ class Entries:
                     labware_barcode="labware1",
                     location_barcode="unordered_location1",
                     full_location_address="PARENT / unordered_location1",
+                    location_name="unordered_location1",
                     coordinate_position=None,
                     coordinate_row=None,
                     coordinate_column=None,
@@ -338,6 +383,7 @@ class Entries:
                     labware_barcode="labware3",
                     location_barcode="ordered_location2",
                     full_location_address="PARENT / ordered_location2",
+                    location_name="ordered_location2",
                     coordinate_position=1,
                     coordinate_row=1,
                     coordinate_column=1,
@@ -352,6 +398,7 @@ class Entries:
                     labware_barcode="labware5",
                     location_barcode="unordered_location3",
                     full_location_address="PARENT / unordered_location3",
+                    location_name="unordered_location3",
                     coordinate_position=None,
                     coordinate_row=None,
                     coordinate_column=None,
@@ -366,6 +413,7 @@ class Entries:
                     labware_barcode="labware7",
                     location_barcode="unordered_location4",
                     full_location_address="PARENT / unordered_location4",
+                    location_name="unordered_location4",
                     coordinate_position=None,
                     coordinate_row=None,
                     coordinate_column=None,

--- a/tests/data/entries.py
+++ b/tests/data/entries.py
@@ -265,7 +265,12 @@ class Entries:
         return {
             "labwares": [LabwaresTableEntry(id=6, barcode="labware6", location_id=6, coordinate_id=None)],
             "locations": [
-                LocationsTableEntry(id=6, barcode="unordered_location6", parentage="PARENT / unordered_location6")
+                LocationsTableEntry(
+                    id=6,
+                    barcode="unordered_location6",
+                    parentage="PARENT / unordered_location6",
+                    name="unordered_location6",
+                )
             ],
         }
 

--- a/tests/db_queries/lw/create_locations.sql
+++ b/tests/db_queries/lw/create_locations.sql
@@ -1,1 +1,1 @@
-CREATE TABLE locations (id int(11) primary key, barcode varchar(255), parentage varchar(255));
+CREATE TABLE locations (id int(11) primary key, barcode varchar(255), parentage varchar(255), name varchar(255));

--- a/tests/db_queries/mlwh/create_labware_location.sql
+++ b/tests/db_queries/mlwh/create_labware_location.sql
@@ -4,6 +4,7 @@ CREATE TABLE labware_location
     labware_barcode varchar(255) NOT NULL UNIQUE,
     location_barcode varchar(255) NOT NULL,
     full_location_address varchar(255) NOT NULL,
+    location_name varchar(255) NOT NULL,
     coordinate_position int(11),
     coordinate_row int(11),
     coordinate_column int(11),

--- a/tests/tasks/labware_location/test_main.py
+++ b/tests/tasks/labware_location/test_main.py
@@ -22,6 +22,7 @@ labware_location_columns = [
     "labware_barcode",
     "location_barcode",
     "full_location_address",
+    "location_name",
     "coordinate_position",
     "coordinate_row",
     "coordinate_column",
@@ -75,7 +76,7 @@ def write_to_tables(
         lw_database.write_entries_to_table(insert_into_table_query, users_entries, len(users_entries))
 
     if locations_entries:
-        insert_into_table_query = "INSERT INTO locations (id, barcode, parentage) VALUES (%s, %s, %s);"
+        insert_into_table_query = "INSERT INTO locations (id, barcode, parentage, name) VALUES (%s, %s, %s, %s);"
         lw_database.write_entries_to_table(insert_into_table_query, locations_entries, len(locations_entries))
 
     if coordinates_entries:
@@ -92,6 +93,7 @@ def write_to_tables(
                     labware_barcode,
                     location_barcode,
                     full_location_address,
+                    location_name,
                     coordinate_position,
                     coordinate_row,
                     coordinate_column,
@@ -100,7 +102,7 @@ def write_to_tables(
                     stored_at,
                     created_at,
                     updated_at
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);"""
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);"""
         mlwh_database.write_entries_to_table(
             insert_into_table_query, labware_location_entries, len(labware_location_entries)
         )
@@ -162,6 +164,7 @@ def test_given_good_input_entry_with_location_when_making_mlwh_entry_then_check_
     assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
     assert actual_result["location_barcode"] == expected_result["location_barcode"]
     assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["location_name"] == expected_result["location_name"]
     assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
     assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
     assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
@@ -198,6 +201,7 @@ def test_given_good_input_entry_with_coordinates_when_making_mlwh_entry_then_che
     assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
     assert actual_result["location_barcode"] == expected_result["location_barcode"]
     assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["location_name"] == expected_result["location_name"]
     assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
     assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
     assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
@@ -233,6 +237,7 @@ def test_given_good_input_entry_with_two_audits_when_making_mlwh_entry_then_chec
     assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
     assert actual_result["location_barcode"] == expected_result["location_barcode"]
     assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["location_name"] == expected_result["location_name"]
     assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
     assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
     assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
@@ -269,6 +274,7 @@ def test_given_good_input_entry_outdated_record_in_mlwh_when_checking_entries_th
     assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
     assert actual_result["location_barcode"] == expected_result["location_barcode"]
     assert actual_result["full_location_address"] == expected_result["full_location_address"]
+    assert actual_result["location_name"] == expected_result["location_name"]
     assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
     assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
     assert actual_result["coordinate_column"] == expected_result["coordinate_column"]
@@ -366,6 +372,7 @@ def test_given_mixed_entries_when_writing_entries_then_check_all_entries_process
         assert actual_result["labware_barcode"] == expected_result["labware_barcode"]
         assert actual_result["location_barcode"] == expected_result["location_barcode"]
         assert actual_result["full_location_address"] == expected_result["full_location_address"]
+        assert actual_result["location_name"] == expected_result["location_name"]
         assert actual_result["coordinate_position"] == expected_result["coordinate_position"]
         assert actual_result["coordinate_row"] == expected_result["coordinate_row"]
         assert actual_result["coordinate_column"] == expected_result["coordinate_column"]

--- a/tests/types.py
+++ b/tests/types.py
@@ -27,6 +27,7 @@ class LocationsTableEntry(TypedDict):
     id: int
     barcode: str
     parentage: str
+    name: str
 
 
 class CoordinatesTableEntry(TypedDict):
@@ -42,6 +43,7 @@ class LabwareLocationTableEntry(TypedDict):
     labware_barcode: str
     location_barcode: str
     full_location_address: str
+    location_name: str
     coordinate_position: Optional[int]
     coordinate_row: Optional[int]
     coordinate_column: Optional[int]


### PR DESCRIPTION
Closes #37

#### Changes proposed in this pull request

- Update SQL queries to retrieve locations of plates
  - `get_labware_locations.sql` has been updated to retrieve the location name. The location name can be either from an ordered location (with coordinates) or unordered so only one will have a value while the other is null. I have also reformatted the query to that it is tidier.
  - `write_to_labware_locations.sql` has been updated to include a new column for the location name.
  - `create_locations.sql` and `create_labware_location.sql` have been updated to create these column(s) for unit tests.
- Update helper/utility scripts to handle these new column(s)
  - The column names have been added in `mlwh_helpers.py` and handled appropriately.
  - `types.py` have both been updated to include these columns.
- Update unit tests to include location names
  - `entries.py` has been updated so that all good entries include location name
  - `test_main.py` has been updated to include checks for these location names

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
