### PR TITLE
Swapped tokens for removing old images

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -90,4 +90,4 @@ jobs:
           org-name: sanger
           keep-at-least: 5
           skip-tags: latest, *[!develop] # This will DELETE any images where the tag contains ANY characters in "develop", excluding '!'
-          token: ${{ secrets.REMOVE_OLD_IMAGES }}
+          token: ${{ secrets.ADD_TO_PROJECT_PAT_ORG_WIDE }}


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Testing to see if the token for removing old docker images is still valid

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
