### PR TITLE
Reverted to the old PAT for deleting images

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -90,4 +90,4 @@ jobs:
           org-name: sanger
           keep-at-least: 5
           skip-tags: latest, *[!develop] # This will DELETE any images where the tag contains ANY characters in "develop", excluding '!'
-          token: ${{ secrets.ADD_TO_PROJECT_PAT_ORG_WIDE }}
+          token: ${{ secrets.REMOVE_OLD_IMAGES }}


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- The permissions for the original token were restricting the action from deleting any images. This has now been updated and the original token will continue to be used, but it will expire in July.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
