### PR TITLE
Y25-011 - Bump actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile') }}
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile') }}
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile') }}
@@ -102,7 +102,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile') }}


### PR DESCRIPTION
This PR updates the actions/cache version to v4 in all workflows within this repository.