### PR TITLE
Y26-180 - [PR] Fix Janitor CI

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -81,13 +81,14 @@ jobs:
           docker push docker.pkg.github.com/${IMAGE_NAME}:${{ env.RELEASE_TAG }}
 
       - name: Remove old releases
-        uses: snok/container-retention-policy@v2
+        uses: snok/container-retention-policy@v3.1.0
         with:
-          image-names: ${{ github.event.repository.name }}/*
-          cut-off: Four months ago UTC
-          timestamp-to-use: updated_at
-          account-type: org
-          org-name: sanger
-          keep-at-least: 5
-          skip-tags: latest, *[!develop] # This will DELETE any images where the tag contains ANY characters in "develop", excluding '!'
+          account: sanger
           token: ${{ secrets.REMOVE_OLD_IMAGES }}
+          image-names: ${{ github.event.repository.name }}/*
+          image-tags: "!latest" # never delete the `latest` tag
+          tag-selection: both
+          cut-off: 4months
+          timestamp-to-use: updated_at
+          keep-n-most-recent: 5 # always keep the 5 most recent tagged versions per image
+          dry-run: false

--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -56,12 +56,14 @@ jobs:
         run: echo "RELEASE_TAG=v$RELEASE_NAME" >> $GITHUB_ENV
 
       - name: Create release
-        uses: ncipollo/release-action@v1.8.8
+        uses: ncipollo/release-action@v1.18.0
         with:
           name: ${{ env.RELEASE_NAME }}
           tag: ${{ env.RELEASE_TAG }}
           prerelease: ${{ !(github.ref == 'refs/heads/main') }}
           commit: ${{ github.sha }}
+          # tolerate workflow re-runs without overwriting an existing release
+          skipIfReleaseExists: true
 
       - name: Login to registry
         run: >-

--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -23,9 +23,10 @@ jobs:
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: nelonoel/branch-name@v1.0.1
+      - name: Set BRANCH_NAME
+        run: echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
 
       - name: Build and tag the image for testing and release
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - uses: actions/cache@v4
@@ -43,9 +43,9 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - uses: actions/cache@v4
@@ -67,9 +67,9 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - uses: actions/cache@v4
@@ -97,9 +97,9 @@ jobs:
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - uses: actions/cache@v4
@@ -123,6 +123,6 @@ jobs:
         run: |
           python -m pytest -vx
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -69,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/docker_dispatch.yml
+++ b/.github/workflows/docker_dispatch.yml
@@ -15,7 +15,7 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build the Docker image
         run: >-
           docker build .


### PR DESCRIPTION


#### Changes proposed in this pull request

- [x] snok/container-retention-policy needs update to v3; with parameter changes.
- [x] tolerate workflow re-runs without overwriting an existing release (See scenarios in Notes-2)
- [x] node-20 actions need update to new versions (node-20 was retired)
- [x] REMOVE_OLD_IMAGES token needs rotation (Notes-4)
- [ ] Update the Confluence page about the bot account

##### Notes-2

Prevents `Error 422: Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}`

| Scenario | Tag computed | Behaviour with `skipIfReleaseExists` |
| --- | --- | --- |
| First push to `develop` | `v1.2.3-27752996036-develop` | Created normally. |
| Re-run of that failed run | `v1.2.3-27752996036-develop` (same `RUN_ID`) | Step skips silently, workflow continues to the retention step. |
| New push to `develop` | `v1.2.3-27999999999-develop` (new `RUN_ID`) | Created normally - different tag. |
| Push to `main` with bumped `.release-version` | `v1.2.4` | Created normally. |
| Push to `main` without bumping | `v1.2.3` (collides with previous `main` release) | Step skips silently - handled by `check_release_version.yml` |

##### Notes-4

Login as psd-bot
Use the new password and one of the recovery codes from keepass
Go to Personal access tokens https://github.com/settings/tokens
Generate new token (classic)
Note: GHCR retention policy — REMOVE_OLD_IMAGES org secret (snok/container-retention-policy)
Expiration: Same as the other token
Select scopes: read:packages, delete:packages
Make sure to copy your personal access token now. You won’t be able to see it again!

Test PAT
```
TOKEN='paste_token_here'

curl -s -o /dev/null -w 'list:     %{http_code}\n' \
  -H "Authorization: Bearer $TOKEN" \
  -H "Accept: application/vnd.github+json" \
  'https://api.github.com/orgs/sanger/packages?package_type=container&per_page=1'

curl -s -o /dev/null -w 'versions: %{http_code}\n' \
  -H "Authorization: Bearer $TOKEN" \
  -H "Accept: application/vnd.github+json" \
  'https://api.github.com/orgs/sanger/packages/container/janitor%2Fjanitor/versions?per_page=1'

unset TOKEN
```

Expect both 200

Paste token into the org secret at https://github.com/organizations/sanger/settings/secrets/actions -> REMOVE_OLD_IMAGES -> Enter new value -> save. 


UPDATE: I added psd-bot to sanger members and made Admin on janitor packages.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
